### PR TITLE
:sparkles: Update azure rules

### DIFF
--- a/default/generated/azure/01-azure-aws-config.windup.yaml
+++ b/default/generated/azure/01-azure-aws-config.windup.yaml
@@ -1,0 +1,133 @@
+- category: potential
+  customVariables: []
+  description: |-
+    AWS credential configuration
+    The application contains AWS credential configuration.
+  effort: 1
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/source=eap7
+  - konveyor.io/source=eap
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - AWS
+  links: []
+  message: The application contains AWS credential configuration.
+  ruleID: azure-aws-config-credential-01000
+  when:
+    or:
+    - builtin.filecontent:
+        filePattern: ""
+        pattern: aws_access_key_id
+    - builtin.filecontent:
+        filePattern: ""
+        pattern: aws_secret_access_key
+    - builtin.filecontent:
+        filePattern: ""
+        pattern: aws.credentials
+- category: potential
+  customVariables: []
+  description: |-
+    AWS region configuration
+    The application contains AWS region configuration.
+  effort: 1
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/source=eap7
+  - konveyor.io/source=eap
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - AWS
+  links: []
+  message: The application contains AWS region configuration.
+  ruleID: azure-aws-config-region-02000
+  when:
+    or:
+    - builtin.filecontent:
+        filePattern: ""
+        pattern: aws.region
+    - builtin.filecontent:
+        filePattern: ""
+        pattern: AWS_REGION
+    - builtin.filecontent:
+        filePattern: ""
+        pattern: AWSRegion
+- category: potential
+  customVariables: []
+  description: |-
+    AWS S3 configuration
+    The application contains AWS S3 configuration.. Consider using Azure Blob Storage instead.
+  effort: 1
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/source=eap7
+  - konveyor.io/source=eap
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - AWS
+  links: []
+  message: The application contains AWS S3 configuration.. Consider using Azure Blob
+    Storage instead.
+  ruleID: azure-aws-config-s3-03000
+  when:
+    or:
+    - builtin.filecontent:
+        filePattern: ""
+        pattern: aws.s3
+- category: potential
+  customVariables: []
+  description: |-
+    Amazon Simple Queue Service configuration
+    The application contains Amazon Simple Queue Service configuration.. Consider using Azure Service Bus instead.
+  effort: 1
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/source=eap7
+  - konveyor.io/source=eap
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - AWS
+  links: []
+  message: The application contains Amazon Simple Queue Service configuration.. Consider
+    using Azure Service Bus instead.
+  ruleID: azure-aws-config-sqs-04000
+  when:
+    or:
+    - builtin.filecontent:
+        filePattern: ""
+        pattern: aws.sqs
+- category: potential
+  customVariables: []
+  description: |-
+    AWS Secrets Manager configuration
+    The application contains AWS Secrets Manager configuration.. Consider using Azure Key Vault instead.
+  effort: 1
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/source=eap7
+  - konveyor.io/source=eap
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - AWS
+  links: []
+  message: The application contains AWS Secrets Manager configuration.. Consider using
+    Azure Key Vault instead.
+  ruleID: azure-aws-config-secret-manager-05000
+  when:
+    or:
+    - builtin.filecontent:
+        filePattern: ""
+        pattern: aws.secretsmanager
+    - builtin.filecontent:
+        filePattern: ""
+        pattern: aws-secretsmanager

--- a/default/generated/azure/03-azure-java-version.windup.yaml
+++ b/default/generated/azure/03-azure-java-version.windup.yaml
@@ -1,0 +1,54 @@
+- category: potential
+  customVariables: []
+  description: |-
+    Non-LTS version Java
+    The application is using non-LTS version Java.. JDK on LTS version is recommended, i.e. JAVA_8, JAVA_11 or JAVA_17.
+  effort: 3
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/source=eap7
+  - konveyor.io/source=eap
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - version
+  links: []
+  message: The application is using non-LTS version Java.. JDK on LTS version is recommended,
+    i.e. JAVA_8, JAVA_11 or JAVA_17.
+  ruleID: azure-java-version-01000
+  when:
+    as: result
+    builtin.xml:
+      filepaths:
+      - pom.xml
+      namespaces:
+        m: http://maven.apache.org/POM/4.0.0
+      xpath: //m:java.version[matches(text(), '(9|10|12|13|14|15|16|19|20).*')]
+- category: potential
+  customVariables: []
+  description: |-
+    Java version found to be lower than JAVA_8
+    The application is using Java version lower than JAVA_8.. JDK on LTS version is recommended, i.e. JAVA_8, JAVA_11 or JAVA_17.
+  effort: 3
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/source=eap7
+  - konveyor.io/source=eap
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - version
+  links: []
+  message: The application is using Java version lower than JAVA_8.. JDK on LTS version
+    is recommended, i.e. JAVA_8, JAVA_11 or JAVA_17.
+  ruleID: azure-java-version-02000
+  when:
+    as: result
+    builtin.xml:
+      filepaths:
+      - pom.xml
+      namespaces:
+        m: http://maven.apache.org/POM/4.0.0
+      xpath: //m:java.version[matches(text(), '1\.[0-7]')]

--- a/default/generated/azure/04-azure-logging.windup.yaml
+++ b/default/generated/azure/04-azure-logging.windup.yaml
@@ -1,0 +1,38 @@
+- category: mandatory
+  customVariables: []
+  description: |-
+    Don't log to file system
+    Logging to the file system is not recommended when running applications in the cloud.. Instead, use a console appender to log to standard output.
+  effort: 1
+  labels:
+  - konveyor.io/source=eap7
+  - konveyor.io/source=eap
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - logging
+  links: []
+  message: Logging to the file system is not recommended when running applications
+    in the cloud.. Instead, use a console appender to log to standard output.
+  ruleID: azure-logging-0000
+  tag:
+  - Logging to file system
+  when:
+    or:
+    - builtin.filecontent:
+        filePattern: log{back,4j}.*\.(xml|properties)
+        pattern: (?i)((Daily)?Rolling)?FileAppender|type\s*=\s*((Daily)?Rolling)?File|<\/((Daily)?Rolling)?File>
+    - java.referenced:
+        location: IMPORT
+        pattern: org.apache*log4j*FileAppender*
+    - java.referenced:
+        location: IMPORT
+        pattern: java.util.logging.FileHandler*
+    - java.referenced:
+        location: IMPORT
+        pattern: ch.qos.logback.core.FileAppender
+    - java.referenced:
+        location: IMPORT
+        pattern: org.pmw.tinylog.writers.FileWriter

--- a/default/generated/azure/05-azure-os-specific.windup.yaml
+++ b/default/generated/azure/05-azure-os-specific.windup.yaml
@@ -1,0 +1,45 @@
+- category: mandatory
+  customVariables: []
+  description: |-
+    Windows file system path
+    This file system path is Microsoft Windows platform dependent. It needs to be replaced with a Linux-style path.
+  effort: 1
+  labels:
+  - konveyor.io/source=eap7
+  - konveyor.io/source=eap
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - ms-windows
+  links: []
+  message: This file system path is Microsoft Windows platform dependent. It needs
+    to be replaced with a Linux-style path.
+  ruleID: azure-os-specific-00001
+  when:
+    builtin.filecontent:
+      filePattern: .*\.(java|properties|jsp|jspf|tag|xml|txt)
+      pattern: (\W|\s|^)(?:[a-zA-Z]\:|\\\\[\w\s\.]+)([\\\/][^\n\t]+)+
+- category: mandatory
+  customVariables: []
+  description: |-
+    Dynamic-Link Library (DLL)
+    This Dynamic-Link Library is Microsoft Windows platform dependent. It needs to be replaced with a Linux-style shared library.
+  effort: 5
+  labels:
+  - konveyor.io/source=eap7
+  - konveyor.io/source=eap
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - ms-windows
+  links: []
+  message: This Dynamic-Link Library is Microsoft Windows platform dependent. It needs
+    to be replaced with a Linux-style shared library.
+  ruleID: azure-os-specific-00002
+  when:
+    builtin.file:
+      pattern: .*\.dll

--- a/default/generated/azure/07-spring-boot-to-azure-cache.windup.yaml
+++ b/default/generated/azure/07-spring-boot-to-azure-cache.windup.yaml
@@ -38,3 +38,34 @@
     - java.dependency:
         lowerbound: 0.0.0
         name: org.springframework.integration.spring-integration-redis
+- category: potential
+  customVariables: []
+  description: |-
+    Redis Cache connection string found
+    Redis Cache connection string, username, or password used in this application.. Checkout Azure Cache for Redis for a fully managed cache on Azure.
+  effort: 0
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - cache
+  - redis
+  links:
+  - title: Redis Cache found in the application
+    url: https://learn.microsoft.com/azure/developer/java/migration/migrate-spring-boot-to-azure-spring-apps#identify-external-caches
+  - title: Azure Cache for Redis
+    url: https://azure.microsoft.com/services/cache
+  - title: Spring Data Redis
+    url: https://spring.io/projects/spring-data-redis/
+  - title: Azure Spring Cloud Starter Cache
+    url: https://search.maven.org/artifact/com.azure.spring/azure-spring-cloud-starter-cache
+  message: Redis Cache connection string, username, or password used in this application..
+    Checkout Azure Cache for Redis for a fully managed cache on Azure.
+  ruleID: spring-boot-to-azure-cache-redis-02000
+  when:
+    or:
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: (redis|jedis|lettuce)\.(.*\.)?(url|host|nodes|username|password)

--- a/default/generated/azure/08-spring-boot-to-azure-database.windup.yaml
+++ b/default/generated/azure/08-spring-boot-to-azure-database.windup.yaml
@@ -2,7 +2,7 @@
   customVariables: []
   description: |-
     JDBC connection found in configuration file
-    The application uses a JDBC connection string.. Checkout the different types of databases that are fully managed on Azure.
+    The application uses a JDBC connection string, username or password in the configuration file.. Checkout the different types of databases that are fully managed on Azure.
   effort: 0
   labels:
   - konveyor.io/source=springboot
@@ -23,13 +23,42 @@
     url: https://docs.microsoft.com/azure/developer/java/spring-framework/configure-spring-data-jdbc-with-azure-postgresql
   - title: Use Spring Data JDBC with Azure SQL Database
     url: https://docs.microsoft.com/azure/developer/java/spring-framework/configure-spring-data-jdbc-with-azure-sql-server
-  message: The application uses a JDBC connection string.. Checkout the different
-    types of databases that are fully managed on Azure.
+  message: The application uses a JDBC connection string, username or password in
+    the configuration file.. Checkout the different types of databases that are fully
+    managed on Azure.
   ruleID: spring-boot-to-azure-database-jdbc-01000
   when:
-    builtin.filecontent:
-      filePattern: application.*\.(properties|yaml|yml)
-      pattern: 'jdbc:'
+    or:
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: 'jdbc:'
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: datasource.url
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: datasource.u-r-l
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: datasource.jdbc-url
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: datasource.username
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: datasource.user
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: datasource.password
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: jdbc.url
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: jdbc.username
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: jdbc.password
 - category: potential
   customVariables: []
   description: |-
@@ -57,6 +86,59 @@
     types of databases that are fully managed on Azure.
   ruleID: spring-boot-to-azure-database-mongodb-02000
   when:
-    builtin.filecontent:
-      filePattern: application.*\.(properties|yaml|yml)
-      pattern: 'mongodb:'
+    or:
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: 'mongodb:'
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: mongodb.uri
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: mongodb.username
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: mongodb.password
+- category: potential
+  customVariables: []
+  description: |-
+    R2DBC connection found in configuration file
+    The application uses a R2DBC connection string, username or password in the configuration file.. Checkout the different types of databases that are fully managed on Azure.
+  effort: 0
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - database
+  - r2dbc
+  links:
+  - title: R2DBC connection string found in configuration file
+    url: https://learn.microsoft.com/azure/developer/java/migration/migrate-spring-boot-to-azure-spring-apps#databases
+  - title: Types of Databases on Azure
+    url: https://azure.microsoft.com/product-categories/databases/
+  - title: Use Spring Data R2DBC with Azure Database for MySQL
+    url: https://learn.microsoft.com/azure/developer/java/spring-framework/configure-spring-data-r2dbc-with-azure-mysql
+  - title: Use Spring Data R2DBC with Azure Database for PostgreSQL
+    url: https://learn.microsoft.com/azure/developer/java/spring-framework/configure-spring-data-r2dbc-with-azure-postgresql
+  - title: Use Spring Data R2DBC with Azure SQL Database
+    url: https://learn.microsoft.com/azure/developer/java/spring-framework/configure-spring-data-r2dbc-with-azure-sql-server
+  message: The application uses a R2DBC connection string, username or password in
+    the configuration file.. Checkout the different types of databases that are fully
+    managed on Azure.
+  ruleID: spring-boot-to-azure-database-r2dbc-03000
+  when:
+    or:
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: 'r2dbc:'
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: r2dbc.username
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: r2dbc.password
+    - builtin.filecontent:
+        filePattern: application.*\.(properties|yaml|yml)
+        pattern: r2dbc.url

--- a/default/generated/azure/09-spring-boot-to-azure-eureka.windup.yaml
+++ b/default/generated/azure/09-spring-boot-to-azure-eureka.windup.yaml
@@ -2,7 +2,7 @@
   customVariables: []
   description: |-
     eureka
-    The application uses Eureka.. If a setting like this appears in your application configuration, remove it. Azure Spring Apps will automatically inject the connection information of its configuration server. ```. eureka:. client:. serviceUrl:. defaultZone: http://myusername:mysecretpassword@localhost:8761/eureka/. ```
+    The application uses Eureka.. Azure Spring Apps will host eureka server for you.. Eureka connection configurations will be injected automatically by ASA, if you put these configurations in your Config Server, please remove them.
   effort: 0
   labels:
   - konveyor.io/source=springboot
@@ -12,13 +12,18 @@
   - konveyor.io/target=azure-container-apps
   - eureka
   links:
-  - title: Distributed Tracing
-    url: https://learn.microsoft.com/azure/developer/java/migration/migrate-spring-cloud-to-azure-spring-apps?pivots=sc-standard-tier#remove-explicit-configuration-server-settings
-  message: 'The application uses Eureka.. If a setting like this appears in your application
-    configuration, remove it. Azure Spring Apps will automatically inject the connection
-    information of its configuration server. ```. eureka:. client:. serviceUrl:. defaultZone:
-    http://myusername:mysecretpassword@localhost:8761/eureka/. ```'
+  - title: Azure Spring Apps - Enable Service Registration
+    url: https://learn.microsoft.com/azure/spring-apps/how-to-service-registration?pivots=programming-language-java
+  - title: Azure Spring Apps - Access Config Server and Service Registry
+    url: https://learn.microsoft.com/azure/spring-apps/how-to-access-data-plane-azure-ad-rbac
+  - title: Restricted configurations
+    url: http://aka.ms/spring-cloud-to-asa?pivots=sc-standard-tier#remove-restricted-configurations
+  message: The application uses Eureka.. Azure Spring Apps will host eureka server
+    for you.. Eureka connection configurations will be injected automatically by ASA,
+    if you put these configurations in your Config Server, please remove them.
   ruleID: spring-boot-to-azure-eureka-01000
+  tag:
+  - Eureka
   when:
     or:
     - java.dependency:
@@ -30,3 +35,34 @@
     - java.dependency:
         lowerbound: 0.0.0
         nameregex: com\.netflix\.eureka\..*
+- category: potential
+  customVariables: []
+  description: |-
+    Explicit eureka connection info found in configuration file
+    The application uses an eureka connection string.. Azure Spring Apps will host eureka server for you.. Eureka connection configurations will be injected automatically by ASA, if you put these configurations in your Config Server, please remove them.
+  effort: 0
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-container-apps
+  - eureka
+  links:
+  - title: Azure Spring Apps - Enable Service Registration
+    url: https://learn.microsoft.com/azure/spring-apps/how-to-service-registration?pivots=programming-language-java
+  - title: Azure Spring Apps - Access Config Server and Service Registry
+    url: https://learn.microsoft.com/azure/spring-apps/how-to-access-data-plane-azure-ad-rbac
+  - title: Restricted configurations
+    url: http://aka.ms/spring-cloud-to-asa?pivots=sc-standard-tier#remove-restricted-configurations
+  message: The application uses an eureka connection string.. Azure Spring Apps will
+    host eureka server for you.. Eureka connection configurations will be injected
+    automatically by ASA, if you put these configurations in your Config Server, please
+    remove them.
+  ruleID: spring-boot-to-azure-eureka-02000
+  tag:
+  - Eureka
+  when:
+    builtin.filecontent:
+      filePattern: application.*\.(properties|yaml|yml)
+      pattern: eureka\.client\.(service-url|serviceUrl)

--- a/default/generated/azure/12-spring-boot-to-azure-config-server.windup.yaml
+++ b/default/generated/azure/12-spring-boot-to-azure-config-server.windup.yaml
@@ -1,0 +1,29 @@
+- category: potential
+  customVariables: []
+  description: |-
+    Explicit Config Server connection info found in configuration file
+    The application uses a Spring Cloud Config Server connection string.. If you are migrating to Azure Spring Apps, the connection info of Config Server will be injected upon app start.. Please remove the connection info from your configuration file. Configure the Config Server after creating an Azure Spring Apps instance.
+  effort: 0
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - Spring Cloud Config
+  links:
+  - title: Remove restricted configurations
+    url: http://aka.ms/spring-cloud-to-asa?toc=%2Fazure%2Fspring-apps%2Ftoc.json&bc=%2Fazure%2Fspring-apps%2Fbreadcrumb%2Ftoc.json&pivots=sc-standard-tier#remove-restricted-configurations
+  - title: Prepare the Spring Cloud Config server
+    url: http://aka.ms/spring-cloud-to-asa?toc=%2Fazure%2Fspring-apps%2Ftoc.json&bc=%2Fazure%2Fspring-apps%2Fbreadcrumb%2Ftoc.json&pivots=sc-standard-tier#prepare-the-spring-cloud-config-server
+  message: The application uses a Spring Cloud Config Server connection string.. If
+    you are migrating to Azure Spring Apps, the connection info of Config Server will
+    be injected upon app start.. Please remove the connection info from your configuration
+    file. Configure the Config Server after creating an Azure Spring Apps instance.
+  ruleID: spring-boot-to-azure-config-server-01000
+  tag:
+  - Spring Cloud Config
+  when:
+    builtin.filecontent:
+      filePattern: application.*\.(properties|yaml|yml)
+      pattern: spring\.config\.import|spring\.cloud\.config\.uri

--- a/default/generated/azure/17-spring-boot-to-azure-java-fx.windup.yaml
+++ b/default/generated/azure/17-spring-boot-to-azure-java-fx.windup.yaml
@@ -1,0 +1,21 @@
+- category: mandatory
+  customVariables: []
+  description: |-
+    JavaFX usage
+    The application uses JavaFX.. JavaFX is not cloud compatible and requires the JRE on the remote device.
+  effort: 5
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - JavaFX
+  links: []
+  message: The application uses JavaFX.. JavaFX is not cloud compatible and requires
+    the JRE on the remote device.
+  ruleID: spring-boot-to-azure-java-fx-01000
+  when:
+    java.referenced:
+      location: IMPORT
+      pattern: javafx*

--- a/default/generated/azure/18-spring-boot-to-azure-jks.windup.yaml
+++ b/default/generated/azure/18-spring-boot-to-azure-jks.windup.yaml
@@ -1,0 +1,19 @@
+- category: mandatory
+  customVariables: []
+  description: |-
+    JKS file
+    Java KeyStore file is found. Make sure to externalize the Java Keystore.
+  effort: 1
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - JKS
+  links: []
+  message: Java KeyStore file is found. Make sure to externalize the Java Keystore.
+  ruleID: spring-boot-to-azure-jks-01000
+  when:
+    builtin.file:
+      pattern: .*\.jks

--- a/default/generated/azure/20-spring-boot-to-azure-mq-config.windup.yaml
+++ b/default/generated/azure/20-spring-boot-to-azure-mq-config.windup.yaml
@@ -1,0 +1,80 @@
+- category: potential
+  customVariables: []
+  description: |-
+    Kafka connection string, username or password found in configuration file
+    The application uses a Kafka connection string or password.. Consider connecting Apache Kafka on Confluent Cloud to Azure Spring Apps using Service Connector
+  effort: 0
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - message queue
+  - kafka
+  links:
+  - title: Spring Boot app to Kafka on Confluent Cloud
+    url: https://learn.microsoft.com/azure/service-connector/tutorial-java-spring-confluent-kafka
+  message: The application uses a Kafka connection string or password.. Consider connecting
+    Apache Kafka on Confluent Cloud to Azure Spring Apps using Service Connector
+  ruleID: spring-boot-to-azure-mq-config-kafka-01000
+  tag:
+  - Kafka Client
+  when:
+    builtin.filecontent:
+      filePattern: application.*\.(properties|yaml|yml)
+      pattern: kafka\.(.*\.)?(properties\.)?(bootstrap[\.-]servers|sasl\.jaas\.config|schema\.registry)
+- category: potential
+  customVariables: []
+  description: |-
+    RabbitMQ connection string, username or password found in configuration file
+    The application uses a RabbitMQ connection string, username, or password.. Consider using Azure Event Grid/Azure Event Hubs/Azure Service Bus or Apache Kafka on Confluent Cloud and connect it with Service Connector
+  effort: 0
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - message queue
+  - RabbitMQ Client
+  links:
+  - title: Service connection in Azure Spring Apps
+    url: https://learn.microsoft.com/azure/service-connector/quickstart-portal-spring-cloud-connection
+  message: The application uses a RabbitMQ connection string, username, or password..
+    Consider using Azure Event Grid/Azure Event Hubs/Azure Service Bus or Apache Kafka
+    on Confluent Cloud and connect it with Service Connector
+  ruleID: spring-boot-to-azure-mq-config-rabbitmq-01000
+  tag:
+  - RabbitMQ Client
+  when:
+    builtin.filecontent:
+      filePattern: application.*\.(properties|yaml|yml)
+      pattern: rabbitmq\.(.*\.)?(addresses|host|virtual-host|username|password)
+- category: potential
+  customVariables: []
+  description: |-
+    ActiveMQ Artemis connection string, username or password found in configuration file
+    The application uses an ActiveMQ Artemis connection string, username, or password.. Consider using Azure Event Grid/Azure Event Hubs/Azure Service Bus or Apache Kafka on Confluent Cloud and connect it with Service Connector
+  effort: 0
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - message queue
+  - ActiveMQ
+  links:
+  - title: Service connection in Azure Spring Apps
+    url: https://learn.microsoft.com/azure/service-connector/quickstart-portal-spring-cloud-connection
+  message: The application uses an ActiveMQ Artemis connection string, username, or
+    password.. Consider using Azure Event Grid/Azure Event Hubs/Azure Service Bus
+    or Apache Kafka on Confluent Cloud and connect it with Service Connector
+  ruleID: spring-boot-to-azure-mq-config-artemis-01000
+  tag:
+  - ActiveMQ
+  when:
+    builtin.filecontent:
+      filePattern: application.*\.(properties|yaml|yml)
+      pattern: artemis\.(broker-url|user|password)

--- a/default/generated/azure/21-spring-boot-to-azure-port.windup.yaml
+++ b/default/generated/azure/21-spring-boot-to-azure-port.windup.yaml
@@ -1,0 +1,22 @@
+- category: potential
+  customVariables: []
+  description: |-
+    Server port configuration found
+    The application is setting the server port. Please be aware of potential port reliance issues during the migration process
+  effort: 0
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-container-apps
+  - port
+  - server port
+  links: []
+  message: The application is setting the server port. Please be aware of potential
+    port reliance issues during the migration process
+  ruleID: spring-boot-to-azure-port-01000
+  when:
+    builtin.filecontent:
+      filePattern: application.*\.(properties|yaml|yml)
+      pattern: (^|\s)server\.port

--- a/default/generated/azure/24-spring-boot-to-azure-swing.windup.yaml
+++ b/default/generated/azure/24-spring-boot-to-azure-swing.windup.yaml
@@ -1,0 +1,20 @@
+- category: mandatory
+  customVariables: []
+  description: |-
+    Java Swing usage
+    The application uses Java Swing.. Upgrade to modern cloud native UI framework.
+  effort: 5
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - Swing
+  links: []
+  message: The application uses Java Swing.. Upgrade to modern cloud native UI framework.
+  ruleID: spring-boot-to-azure-swing-01000
+  when:
+    java.referenced:
+      location: IMPORT
+      pattern: javax.swing*

--- a/default/generated/azure/25-spring-boot-to-azure-system-config.windup.yaml
+++ b/default/generated/azure/25-spring-boot-to-azure-system-config.windup.yaml
@@ -1,0 +1,35 @@
+- category: optional
+  customVariables: []
+  description: |-
+    The application uses environment variables/system properties
+    Review the usage of environment variables and system properties and externalize them.. You can inject any per-service configuration settings into each service as environment variables.. Any system properties that the code depends on will need to be defined in JVM options.
+  effort: 1
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - config
+  links:
+  - title: Configure per-service secrets and externalized settings
+    url: https://learn.microsoft.com/azure/developer/java/migration/migrate-spring-boot-to-azure-spring-apps#configure-per-service-secrets-and-externalized-settings
+  message: Review the usage of environment variables and system properties and externalize
+    them.. You can inject any per-service configuration settings into each service
+    as environment variables.. Any system properties that the code depends on will
+    need to be defined in JVM options.
+  ruleID: spring-boot-to-azure-system-config-01000
+  when:
+    or:
+    - java.referenced:
+        location: METHOD_CALL
+        pattern: java.lang.System.getenv*
+    - java.referenced:
+        location: METHOD_CALL
+        pattern: java.lang.System.getProperty*
+    - java.referenced:
+        location: METHOD_CALL
+        pattern: java.lang.System.setProperty*
+    - java.referenced:
+        location: METHOD_CALL
+        pattern: java.lang.System.setProperties*

--- a/default/generated/azure/26-spring-boot-to-azure-version.windup.yaml
+++ b/default/generated/azure/26-spring-boot-to-azure-version.windup.yaml
@@ -1,0 +1,72 @@
+- category: mandatory
+  customVariables: []
+  description: |-
+    Spring Boot version too low
+    The application uses Spring Boot 1.x, which is too low.. Update to open source support version of Spring Boot.
+  effort: 5
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - version
+  links:
+  - title: Spring Boot Support Versions
+    url: https://github.com/spring-projects/spring-boot/wiki/Supported-Versions
+  message: The application uses Spring Boot 1.x, which is too low.. Update to open
+    source support version of Spring Boot.
+  ruleID: spring-boot-to-azure-version-01000
+  when:
+    java.dependency:
+      lowerbound: "1"
+      nameregex: org\.springframework\.boot\..*
+      upperbound: "1.9"
+- category: potential
+  customVariables: []
+  description: |-
+    Spring Boot version out of support
+    Spring boot version is out of any spring boot support scope.. Update to open source support version of Spring Boot.
+  effort: 2
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - version
+  links:
+  - title: Spring Boot Supported Versions
+    url: https://github.com/spring-projects/spring-boot/wiki/Supported-Versions
+  message: Spring boot version is out of any spring boot support scope.. Update to
+    open source support version of Spring Boot.
+  ruleID: spring-boot-to-azure-version-02000
+  when:
+    java.dependency:
+      lowerbound: "2"
+      nameregex: org\.springframework\.boot\..*
+      upperbound: 2.4.99
+- category: potential
+  customVariables: []
+  description: |-
+    Spring Boot version out of OSS support
+    Spring Boot version is out of open source software support.. Update to open source support version of Spring Boot, if you don't have commercial support.
+  effort: 1
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - version
+  links:
+  - title: Spring Boot Supported Versions
+    url: https://github.com/spring-projects/spring-boot/wiki/Supported-Versions
+  message: Spring Boot version is out of open source software support.. Update to
+    open source support version of Spring Boot, if you don't have commercial support.
+  ruleID: spring-boot-to-azure-version-03000
+  when:
+    java.dependency:
+      lowerbound: "2.5"
+      nameregex: org\.springframework\.boot\..*
+      upperbound: 2.6.99

--- a/default/generated/azure/28-spring-cloud-to-azure-version.windup.yaml
+++ b/default/generated/azure/28-spring-cloud-to-azure-version.windup.yaml
@@ -1,0 +1,77 @@
+- category: mandatory
+  customVariables: []
+  description: |-
+    spring cloud version too low
+    Spring Cloud version too low.. Update to open source support version of Spring Cloud.
+  effort: 5
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-container-apps
+  - version
+  links:
+  - title: Spring Cloud Supported Versions
+    url: https://github.com/spring-cloud/spring-cloud-release/wiki/Supported-Versions
+  message: Spring Cloud version too low.. Update to open source support version of
+    Spring Cloud.
+  ruleID: spring-cloud-to-azure-version-01000
+  when:
+    java.dependency:
+      lowerbound: Angel
+      name: org.springframework.cloud.spring-cloud-dependencies
+      upperbound: Edgware.9
+- category: potential
+  customVariables: []
+  description: |-
+    spring cloud version out of support
+    Spring Cloud version is out of any Spring Cloud support scope.. Update to open source support version of Spring Cloud.
+  effort: 2
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-container-apps
+  - version
+  links:
+  - title: Spring Cloud Supported Versions
+    url: https://github.com/spring-cloud/spring-cloud-release/wiki/Supported-Versions
+  message: Spring Cloud version is out of any Spring Cloud support scope.. Update
+    to open source support version of Spring Cloud.
+  ruleID: spring-cloud-to-azure-version-02000
+  when:
+    java.dependency:
+      lowerbound: Finchley
+      name: org.springframework.cloud.spring-cloud-dependencies
+      upperbound: Hoxton.9
+- category: potential
+  customVariables: []
+  description: |-
+    spring cloud version out of OSS support
+    Spring Cloud version is out of open source software support.. Update to open source support version of Spring Cloud, if you don't have commercial support.
+  effort: 1
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-container-apps
+  - version
+  links:
+  - title: Spring Cloud Supported Versions
+    url: https://github.com/spring-cloud/spring-cloud-release/wiki/Supported-Versions
+  message: Spring Cloud version is out of open source software support.. Update to
+    open source support version of Spring Cloud, if you don't have commercial support.
+  ruleID: spring-cloud-to-azure-version-03000
+  when:
+    or:
+    - java.dependency:
+        lowerbound: Ilford
+        name: org.springframework.cloud.spring-cloud-dependencies
+        upperbound: Ilford.9
+    - java.dependency:
+        lowerbound: "2020"
+        name: org.springframework.cloud.spring-cloud-dependencies
+        upperbound: "2020.9"

--- a/default/generated/azure/29-tomcat-to-azure-external-resources.windup.yaml
+++ b/default/generated/azure/29-tomcat-to-azure-external-resources.windup.yaml
@@ -1,0 +1,26 @@
+- category: mandatory
+  customVariables: []
+  description: |-
+    External resources found in configuration file
+    External resources, such as data sources, JMS message brokers, and others are injected via Java Naming and Directory Interface (JNDI).. Some such resources may require migration or reconfiguration.
+  effort: 5
+  labels:
+  - konveyor.io/target=azure-spring-apps
+  - konveyor.io/target=azure-appservice
+  - konveyor.io/target=azure-aks
+  - konveyor.io/target=azure-container-apps
+  - konveyor.io/source
+  - tomcat
+  links:
+  - title: Inventory external resources
+    url: https://learn.microsoft.com/azure/developer/java/migration/migrate-tomcat-to-azure-spring-apps
+  message: External resources, such as data sources, JMS message brokers, and others
+    are injected via Java Naming and Directory Interface (JNDI).. Some such resources
+    may require migration or reconfiguration.
+  ruleID: tomcat-to-azure-external-resources-01000
+  when:
+    builtin.xml:
+      filepaths:
+      - context.xml
+      namespaces: {}
+      xpath: /Context/Resource


### PR DESCRIPTION
In order to properly see the diffs, some prefixes in the filenames are repeated. This is due to new rules being created and the ordering changing.

Coverage in the `azure` directory improves from 50.00% (9/18) to 61.70% (29/47).