### PR TITLE
:bug: Add 'name' for cloud-readiness ruleset

### DIFF
--- a/default/generated/cloud-readiness/ruleset.yaml
+++ b/default/generated/cloud-readiness/ruleset.yaml
@@ -1,2 +1,3 @@
+name: cloud-readiness
 description: This ruleset detects logging configurations that may be problematic when
   migrating an application to a cloud environment.


### PR DESCRIPTION
Fixes #36 

Background:  We changed the name of the ruleset from 'openshift' to 'cloud-readiness' to match what WindUp recently did, but we forgot to add a 'name' to the ruleset metadata

https://github.com/konveyor/rulesets/pull/35/files#diff-4061c07abe70df3b8ff93f0fd18d53ff17d843cac042d4a1ad6e5f363778398a