### PR TITLE
:bug: Turn * endings into (*)

### DIFF
--- a/default/generated/azure/07-eap-to-azure-appservice-certificates.windup.yaml
+++ b/default/generated/azure/07-eap-to-azure-appservice-certificates.windup.yaml
@@ -20,7 +20,7 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.security.KeyStore.getInstance*
+        pattern: java.security.KeyStore.getInstance(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.security.KeyStore.load*
+        pattern: java.security.KeyStore.load(*)

--- a/default/generated/azure/09-eap-to-azure-appservice-environment-variables.windup.yaml
+++ b/default/generated/azure/09-eap-to-azure-appservice-environment-variables.windup.yaml
@@ -26,7 +26,7 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.System.getenv*
+        pattern: java.lang.System.getenv(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.System.getProperty*
+        pattern: java.lang.System.getProperty(*)

--- a/default/generated/azure/25-spring-boot-to-azure-system-config.windup.yaml
+++ b/default/generated/azure/25-spring-boot-to-azure-system-config.windup.yaml
@@ -23,13 +23,13 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.System.getenv*
+        pattern: java.lang.System.getenv(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.System.getProperty*
+        pattern: java.lang.System.getProperty(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.System.setProperty*
+        pattern: java.lang.System.setProperty(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.System.setProperties*
+        pattern: java.lang.System.setProperties(*)

--- a/default/generated/camel3/33-java-generic-information.groovy.windup.yaml
+++ b/default/generated/camel3/33-java-generic-information.groovy.windup.yaml
@@ -35,7 +35,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.apache.camel.impl.SimpleRegistry.put*
+      pattern: org.apache.camel.impl.SimpleRegistry.put(*)  # put, putIfAbsent, putAll
 - category: optional
   customVariables: []
   description: getOut/hasOut are deprecated
@@ -101,13 +101,13 @@
         pattern: org.apache.camel.CamelContext.(start|stop|suspend|resume)Route*
     - java.referenced:
         location: METHOD_CALL
-        pattern: org.apache.camel.CamelContext.startAllRoutes*
+        pattern: org.apache.camel.CamelContext.startAllRoutes(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: org.apache.camel.CamelContext.isStartingRoutes*
+        pattern: org.apache.camel.CamelContext.isStartingRoutes(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: org.apache.camel.CamelContext.getRouteStatus*
+        pattern: org.apache.camel.CamelContext.getRouteStatus(*)
 - category: mandatory
   customVariables:
   - name: param

--- a/default/generated/cloud-readiness/69-jni-native-code.windup.yaml
+++ b/default/generated/cloud-readiness/69-jni-native-code.windup.yaml
@@ -27,19 +27,19 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.System.load*
+        pattern: java.lang.System.load(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.System.loadLibrary*
+        pattern: java.lang.System.loadLibrary(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.System.mapLibraryName*
+        pattern: java.lang.System.mapLibraryName(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.Runtime.load*
+        pattern: java.lang.Runtime.load(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.Runtime.loadLibrary*
+        pattern: java.lang.Runtime.loadLibrary(*)
     - java.referenced:
         location: CONSTRUCTOR_CALL
         pattern: com.sun.jna*

--- a/default/generated/cloud-readiness/70-local-storage.windup.yaml
+++ b/default/generated/cloud-readiness/70-local-storage.windup.yaml
@@ -42,7 +42,7 @@
         pattern: java.util.zip.ZipFile*
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.io.File.createTempFile*
+        pattern: java.io.File.createTempFile(*)
     - java.referenced:
         location: METHOD_CALL
         pattern: java.nio.file.Paths.get*

--- a/default/generated/cloud-readiness/74-session.windup.yaml
+++ b/default/generated/cloud-readiness/74-session.windup.yaml
@@ -73,7 +73,7 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: javax.servlet.http.HttpSession.setAttribute*
+        pattern: javax.servlet.http.HttpSession.setAttribute(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: javax.servlet.http.HttpSession.putValue*
+        pattern: javax.servlet.http.HttpSession.putValue(*)

--- a/default/generated/eap6/95-environment-dependent.windup.yaml
+++ b/default/generated/eap6/95-environment-dependent.windup.yaml
@@ -25,7 +25,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: java.lang.Class.forName*
+      pattern: java.lang.Class.forName(*)
 - category: mandatory
   customVariables: []
   description: Call of JNDI lookup
@@ -59,7 +59,7 @@
     as: default
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.naming.Context.lookup*
+      pattern: javax.naming.Context.lookup(*)
 - category: mandatory
   customVariables: []
   description: Proprietary InitialContext initialization
@@ -182,4 +182,4 @@
     as: default
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.management.remote.JMXConnectorFactory.connect*
+      pattern: javax.management.remote.JMXConnectorFactory.connect(*)

--- a/default/generated/eap7/110-hibernate4.windup.yaml
+++ b/default/generated/eap7/110-hibernate4.windup.yaml
@@ -23,7 +23,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.addFile*
+      pattern: org.hibernate.cfg.Configuration.addFile(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.add()
@@ -49,7 +49,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.add*
+      pattern: org.hibernate.cfg.Configuration.add(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.addXML()
@@ -75,7 +75,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.addXML*
+      pattern: org.hibernate.cfg.Configuration.addXML(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.addCacheableFile()
@@ -101,7 +101,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.addCacheableFile*
+      pattern: org.hibernate.cfg.Configuration.addCacheableFile(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.addURL()
@@ -127,7 +127,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.addURL*
+      pattern: org.hibernate.cfg.Configuration.addURL(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.addInputStream()
@@ -153,7 +153,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.addInputStream*
+      pattern: org.hibernate.cfg.Configuration.addInputStream(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.addResource()
@@ -179,7 +179,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.addResource*
+      pattern: org.hibernate.cfg.Configuration.addResource(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.addClass()
@@ -205,7 +205,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.addClass*
+      pattern: org.hibernate.cfg.Configuration.addClass(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.addAnnotatedClass()
@@ -231,7 +231,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.addAnnotatedClass*
+      pattern: org.hibernate.cfg.Configuration.addAnnotatedClass(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.addPackage()
@@ -257,7 +257,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.addPackage*
+      pattern: org.hibernate.cfg.Configuration.addPackage(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.addJar()
@@ -283,7 +283,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.addJar*
+      pattern: org.hibernate.cfg.Configuration.addJar(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.addDirectory()
@@ -309,7 +309,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.addDirectory*
+      pattern: org.hibernate.cfg.Configuration.addDirectory(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.registerTypeContributor()
@@ -335,7 +335,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.registerTypeContributor*
+      pattern: org.hibernate.cfg.Configuration.registerTypeContributor(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.registerTypeOverride()
@@ -361,7 +361,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.registerTypeOverride*
+      pattern: org.hibernate.cfg.Configuration.registerTypeOverride(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.setProperty()
@@ -388,7 +388,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.setProperty*
+      pattern: org.hibernate.cfg.Configuration.setProperty(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.setProperties()
@@ -414,7 +414,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.setProperties*
+      pattern: org.hibernate.cfg.Configuration.setProperties(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.addProperties()
@@ -441,7 +441,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.addProperties*
+      pattern: org.hibernate.cfg.Configuration.addProperties(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.setNamingStrategy()
@@ -476,7 +476,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.setNamingStrategy*
+      pattern: org.hibernate.cfg.Configuration.setNamingStrategy(*)
 - category: optional
   customVariables:
   - name: configure
@@ -532,7 +532,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.setInterceptor*
+      pattern: org.hibernate.cfg.Configuration.setInterceptor(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.setEntityNotFoundDelegate()
@@ -559,7 +559,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.setEntityNotFoundDelegate*
+      pattern: org.hibernate.cfg.Configuration.setEntityNotFoundDelegate(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.setSessionFactoryObserver()
@@ -586,7 +586,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.setSessionFactoryObserver*
+      pattern: org.hibernate.cfg.Configuration.setSessionFactoryObserver(*)
 - category: optional
   customVariables: []
   description: Hibernate 5 - Deprecated method org.hibernate.cfg.Configuration.setCurrentTenantIdentifierResolver()
@@ -613,7 +613,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.cfg.Configuration.setCurrentTenantIdentifierResolver*
+      pattern: org.hibernate.cfg.Configuration.setCurrentTenantIdentifierResolver(*)
 - category: optional
   customVariables:
   - name: type

--- a/default/generated/eap7/111-hsearch.windup.yaml
+++ b/default/generated/eap7/111-hsearch.windup.yaml
@@ -813,10 +813,10 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: org.hibernate.search.query.dsl.QueryBuilder.facet*
+        pattern: org.hibernate.search.query.dsl.QueryBuilder.facet(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: org.hibernate.search.FullTextQuery.getFacetManager*
+        pattern: org.hibernate.search.FullTextQuery.getFacetManager(*)
     - java.referenced:
         pattern: org.hibernate.search.query.facet.(Facet|FacetingRequest|FacetSelection|FacetSortOrder|RangeFacet)
 - category: optional
@@ -965,7 +965,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.search.cfg.ContainedInMapping.numericField*
+      pattern: org.hibernate.search.cfg.ContainedInMapping.numericField(*)
 - category: optional
   customVariables: []
   description: Hibernate Search 5 - Deprecated method FullTextSharedSessionBuilder#autoClose
@@ -992,7 +992,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.search.FullTextSharedSessionBuilder.autoClose*
+      pattern: org.hibernate.search.FullTextSharedSessionBuilder.autoClose(*)
 - category: optional
   customVariables: []
   description: Hibernate Search 5 - Deprecated method IndexedMapping#cacheFromIndex
@@ -1018,7 +1018,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.search.cfg.IndexedMapping.cacheFromIndex*
+      pattern: org.hibernate.search.cfg.IndexedMapping.cacheFromIndex(*)
 - category: optional
   customVariables: []
   description: Hibernate Search 5 - Deprecated method EntityDescriptor#getCacheInMemory
@@ -1044,7 +1044,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.search.cfg.EntityDescriptor.getCacheInMemory*
+      pattern: org.hibernate.search.cfg.EntityDescriptor.getCacheInMemory(*)
 - category: optional
   customVariables: []
   description: Hibernate Search 5 - Deprecated method HSQuery#getExtendedSearchIntegrator
@@ -1070,7 +1070,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.search.query.engine.spi.HSQuery.getExtendedSearchIntegrator*
+      pattern: org.hibernate.search.query.engine.spi.HSQuery.getExtendedSearchIntegrator(*)
 - category: optional
   customVariables: []
   description: Hibernate Search 5 - Deprecated method DocumentBuilderIndexedEntity#getFieldCacheOption
@@ -1097,7 +1097,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity.getFieldCacheOption*
+      pattern: org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity.getFieldCacheOption(*)
 - category: optional
   customVariables: []
   description: Hibernate Search 5 - Deprecated method BuildContext#getIndexingStrategy
@@ -1122,7 +1122,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.search.spi.BuildContext.getIndexingStrategy*
+      pattern: org.hibernate.search.spi.BuildContext.getIndexingStrategy(*)
 - category: optional
   customVariables: []
   description: Hibernate Search 5 - Deprecated method DirectoryHelper#getVerifiedIndexDir
@@ -1148,7 +1148,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.search.store.spi.DirectoryHelper.getVerifiedIndexDir*
+      pattern: org.hibernate.search.store.spi.DirectoryHelper.getVerifiedIndexDir(*)
 - category: optional
   customVariables: []
   description: Hibernate Search 5 - Deprecated method EntityDescriptor#setCacheInMemory
@@ -1175,7 +1175,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.search.cfg.EntityDescriptor.setCacheInMemory*
+      pattern: org.hibernate.search.cfg.EntityDescriptor.setCacheInMemory(*)
 - category: optional
   customVariables: []
   description: Hibernate Search 5 - Deprecated method MassIndexer#threadsForSubsequentFetching
@@ -1202,7 +1202,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.search.MassIndexer.threadsForSubsequentFetching*
+      pattern: org.hibernate.search.MassIndexer.threadsForSubsequentFetching(*)
 - category: optional
   customVariables: []
   description: Hibernate Search 5 - Deprecated method FuzzyContext#withThreshold
@@ -1228,7 +1228,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.search.query.dsl.FuzzyContext.withThreshold*
+      pattern: org.hibernate.search.query.dsl.FuzzyContext.withThreshold(*)
 - category: optional
   customVariables:
   - name: type
@@ -1759,4 +1759,4 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.search.MassIndexer.threadsForIndexWriter*
+      pattern: org.hibernate.search.MassIndexer.threadsForIndexWriter(*)

--- a/default/generated/eap7/113-resteasy.windup.yaml
+++ b/default/generated/eap7/113-resteasy.windup.yaml
@@ -841,7 +841,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.jboss.resteasy.plugins.delegates.ServerCookie.checkName*
+      pattern: org.jboss.resteasy.plugins.delegates.ServerCookie.checkName(*)
 - category: optional
   customVariables: []
   description: Deprecated method JAXBContextWrapper#createValidator in RESTEasy 3
@@ -864,7 +864,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.jboss.resteasy.plugins.providers.jaxb.JAXBContextWrapper.createValidator*
+      pattern: org.jboss.resteasy.plugins.providers.jaxb.JAXBContextWrapper.createValidator(*)
 - category: optional
   customVariables: []
   description: Deprecated method ResteasyHttpServletResponseWrapper#encodeRedirectUrl
@@ -890,7 +890,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.jboss.resteasy.core.ResteasyHttpServletResponseWrapper.encodeRedirectUrl*
+      pattern: org.jboss.resteasy.core.ResteasyHttpServletResponseWrapper.encodeRedirectUrl(*)
 - category: optional
   customVariables: []
   description: Deprecated ResteasyHttpServletResponseWrapper#encodeUrl method
@@ -916,7 +916,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.jboss.resteasy.core.ResteasyHttpServletResponseWrapper.encodeUrl*
+      pattern: org.jboss.resteasy.core.ResteasyHttpServletResponseWrapper.encodeUrl(*)
 - category: optional
   customVariables: []
   description: Deprecated method MultipartFormDataInputImpl#getFormData in RESTEasy
@@ -943,7 +943,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInputImpl.getFormData*
+      pattern: org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInputImpl.getFormData(*)
 - category: optional
   customVariables: []
   description: Deprecated method MultipartFormDataInput#getFormData in RESTEasy 3
@@ -969,7 +969,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput.getFormData*
+      pattern: org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput.getFormData(*)
 - category: optional
   customVariables: []
   description: Deprecated method ResteasyHttpServletRequestWrapper.isRequestedSessionIdFromURL
@@ -996,7 +996,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.jboss.resteasy.core.ResteasyHttpServletRequestWrapper.isRequestedSessionIdFromUrl*
+      pattern: org.jboss.resteasy.core.ResteasyHttpServletRequestWrapper.isRequestedSessionIdFromUrl(*)
 - category: optional
   customVariables: []
   description: Deprecated method SecureUnmarshaller#isValidating in RESTEasy 3
@@ -1022,7 +1022,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.jboss.resteasy.plugins.providers.jaxb.SecureUnmarshaller.isValidating*
+      pattern: org.jboss.resteasy.plugins.providers.jaxb.SecureUnmarshaller.isValidating(*)
 - category: optional
   customVariables: []
   description: Deprecated method ServerCookie#maybeQuote in RESTEasy 3
@@ -1049,7 +1049,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.jboss.resteasy.plugins.delegates.ServerCookie.maybeQuote*
+      pattern: org.jboss.resteasy.plugins.delegates.ServerCookie.maybeQuote(*)
 - category: optional
   customVariables: []
   description: Deprecated method SecureUnmarshaller#setAdapter in RESTEasy 3
@@ -1075,7 +1075,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.jboss.resteasy.plugins.providers.jaxb.SecureUnmarshaller.setAdapter*
+      pattern: org.jboss.resteasy.plugins.providers.jaxb.SecureUnmarshaller.setAdapter(*)
 - category: optional
   customVariables: []
   description: Deprecated method ResteasyHttpServletResponseWrapper#setStatus in RESTEasy
@@ -1103,7 +1103,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.jboss.resteasy.core.ResteasyHttpServletResponseWrapper.setStatus*
+      pattern: org.jboss.resteasy.core.ResteasyHttpServletResponseWrapper.setStatus(*)
 - category: optional
   customVariables: []
   description: Deprecated method SecureUnmarshaller#setValidating in RESTEasy 3
@@ -1129,7 +1129,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.jboss.resteasy.plugins.providers.jaxb.SecureUnmarshaller.setValidating*
+      pattern: org.jboss.resteasy.plugins.providers.jaxb.SecureUnmarshaller.setValidating(*)
 - category: optional
   customVariables: []
   description: Deprecated method OAuthValidator#validateMessage in RESTEasy 3
@@ -1155,7 +1155,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.jboss.resteasy.auth.oauth.OAuthValidator.validateMessage*
+      pattern: org.jboss.resteasy.auth.oauth.OAuthValidator.validateMessage(*)
 - category: mandatory
   customVariables: []
   description: Resteasy Yaml Provider is deprecated and disabled by default

--- a/default/generated/eap7/116-hibernate51-53.windup.yaml
+++ b/default/generated/eap7/116-hibernate51-53.windup.yaml
@@ -136,7 +136,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.engine.spi.SessionFactoryImplementor.getQueryCache*
+      pattern: org.hibernate.engine.spi.SessionFactoryImplementor.getQueryCache(*)
 - category: mandatory
   customVariables: []
   description: Hibernate 5.3 - SessionFactoryImplementor.getQueryCache(String regionName)
@@ -186,7 +186,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.engine.spi.SessionFactoryImplementor.getUpdateTimestampsCache*
+      pattern: org.hibernate.engine.spi.SessionFactoryImplementor.getUpdateTimestampsCache(*)
 - category: mandatory
   customVariables: []
   description: Hibernate 5.3 - SessionFactoryImplementor.getSecondLevelCacheRegion(String
@@ -315,7 +315,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.engine.spi.SessionFactoryImplementor.getAllSecondLevelCacheRegions*
+      pattern: org.hibernate.engine.spi.SessionFactoryImplementor.getAllSecondLevelCacheRegions(*)
 - category: mandatory
   customVariables:
   - name: className

--- a/default/generated/eap7/117-picketlink25.windup.yaml
+++ b/default/generated/eap7/117-picketlink25.windup.yaml
@@ -19,4 +19,4 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.picketlink.identity.federation.api.wstrust.WSTrustClient.issueToken*
+      pattern: org.picketlink.identity.federation.api.wstrust.WSTrustClient.issueToken(*)

--- a/default/generated/eap7/135-weblogic-webservices.windup.yaml
+++ b/default/generated/eap7/135-weblogic-webservices.windup.yaml
@@ -80,7 +80,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: weblogic.wsee.connection.transport.http.HttpTransportInfo.setUsername*
+      pattern: weblogic.wsee.connection.transport.http.HttpTransportInfo.setUsername(*)
 - category: mandatory
   customVariables: []
   description: WebLogic proprietary web services API - weblogic.wsee.context.WebServiceContext

--- a/default/generated/eap7/137-weblogic.windup.yaml
+++ b/default/generated/eap7/137-weblogic.windup.yaml
@@ -187,8 +187,11 @@
   ruleID: weblogic-eap7-08000
   when:
     java.referenced:
-      location: METHOD_CALL
-      pattern: weblogic.transaction.(Client)*TxHelper.getTransactionManager*
+      or:
+      - location: METHOD_CALL
+        pattern: weblogic.transaction.ClientTxHelper.getTransactionManager(*)
+      - location: METHOD_CALL
+        pattern: weblogic.transaction.TxHelper.getTransactionManager(*)
 - category: mandatory
   customVariables: []
   description: WebLogic proprietary Clob JDBC object (OracleThinClob)

--- a/default/generated/eap7/137-weblogic.windup.yaml
+++ b/default/generated/eap7/137-weblogic.windup.yaml
@@ -106,16 +106,16 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: weblogic.transaction.TransactionManager.resume*
+        pattern: weblogic.transaction.TransactionManager.resume(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: weblogic.transaction.TransactionManager.forceResume*
+        pattern: weblogic.transaction.TransactionManager.forceResume(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: weblogic.transaction.ClientTransactionManager.resume*
+        pattern: weblogic.transaction.ClientTransactionManager.resume(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: weblogic.transaction.ClientTransactionManager.forceResume*
+        pattern: weblogic.transaction.ClientTransactionManager.forceResume(*)
 - category: mandatory
   customVariables: []
   description: WebLogic TransactionManager usage of suspend method
@@ -134,16 +134,16 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: weblogic.transaction.TransactionManager.suspend*
+        pattern: weblogic.transaction.TransactionManager.suspend(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: weblogic.transaction.TransactionManager.forceSuspend*
+        pattern: weblogic.transaction.TransactionManager.forceSuspend(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: weblogic.transaction.ClientTransactionManager.suspend*
+        pattern: weblogic.transaction.ClientTransactionManager.suspend(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: weblogic.transaction.ClientTransactionManager.forceSuspend*
+        pattern: weblogic.transaction.ClientTransactionManager.forceSuspend(*)
 - category: mandatory
   customVariables: []
   description: WebLogic TxHelper usage
@@ -232,7 +232,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: weblogic.jdbc.vendor.oracle.OracleThinClob.getCharacterOutputStream*
+      pattern: weblogic.jdbc.vendor.oracle.OracleThinClob.getCharacterOutputStream(*)
 - category: mandatory
   customVariables: []
   description: WebLogic proprietary logger (NonCatalogLogger)
@@ -262,7 +262,7 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: weblogic.i18n.logging.NonCatalogLogger*
+        pattern: weblogic.i18n.logging.NonCatalogLogger(*)
     - java.referenced:
         location: CONSTRUCTOR_CALL
         pattern: weblogic.i18n.logging.NonCatalogLogger*

--- a/default/generated/eap8/147-eap8-xml-binding.windup.yaml
+++ b/default/generated/eap8/147-eap8-xml-binding.windup.yaml
@@ -47,7 +47,7 @@
     as: setPropertiesMethodCalls
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.xml.bind.Marshaller.setProperty*
+      pattern: javax.xml.bind.Marshaller.setProperty(*)
 - category: mandatory
   customVariables: []
   description: The URI in the JAXB binding file should be updated
@@ -125,7 +125,7 @@
     as: instanceMethods
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.xml.bind.JAXBContext.newInstance*
+      pattern: javax.xml.bind.JAXBContext.newInstance(*)
 - category: mandatory
   customVariables: []
   description: Usage of this Validator interface or retrieval method should be removed
@@ -153,7 +153,7 @@
         pattern: javax.xml.bind.Validator
     - java.referenced:
         location: METHOD_CALL
-        pattern: javax.xml.bind.JAXBContext.createValidator*
+        pattern: javax.xml.bind.JAXBContext.createValidator(*)
 - category: potential
   customVariables: []
   description: Implementation or use by the application of the javax.xml.bind.Marshaller
@@ -180,7 +180,7 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: javax.xml.bind.Marshaller.setAdapter*
+        pattern: javax.xml.bind.Marshaller.setAdapter(*)
 - category: mandatory
   customVariables: []
   description: Outdated JAXB dependency
@@ -231,4 +231,4 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: javax.xml.bind.Marshaller.getAdapter*
+        pattern: javax.xml.bind.Marshaller.getAdapter(*)

--- a/default/generated/eap8/148-eap8.ejb.windup.yaml
+++ b/default/generated/eap8/148-eap8.ejb.windup.yaml
@@ -20,10 +20,10 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: javax.ejb.EJBContext.getCallerIdentity*
+        pattern: javax.ejb.EJBContext.getCallerIdentity(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: javax.ejb.EJBContext.isCallerInRole*
+        pattern: javax.ejb.EJBContext.isCallerInRole(*)
 - category: mandatory
   customVariables: []
   description: javax.ejb.EJBContext.getEnvironment() method removed
@@ -45,7 +45,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.ejb.EJBContext.getEnvironment*
+      pattern: javax.ejb.EJBContext.getEnvironment(*)
 - category: mandatory
   customVariables: []
   description: javax.ejb.SessionContext.getMessageContext() method removed
@@ -66,4 +66,4 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.ejb.SessionContext.getMessageContext*
+      pattern: javax.ejb.SessionContext.getMessageContext(*)

--- a/default/generated/eap8/151-hibernate-6.2.windup.yaml
+++ b/default/generated/eap8/151-hibernate-6.2.windup.yaml
@@ -22,7 +22,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.persister.entity.EntityPersister.multiload*
+      pattern: org.hibernate.persister.entity.EntityPersister.multiload(*)
 - category: mandatory
   customVariables: []
   description: Executable#afterDeserialize method has changed
@@ -47,7 +47,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.action.spi.Executable.afterDeserialize*
+      pattern: org.hibernate.action.spi.Executable.afterDeserialize(*)
 - category: mandatory
   customVariables: []
   description: JdbcType#getJdbcRecommendedJavaTypeMapping() method has changed
@@ -70,7 +70,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.type.descriptor.jdbc.JdbcType.getJdbcRecommendedJavaTypeMapping*
+      pattern: org.hibernate.type.descriptor.jdbc.JdbcType.getJdbcRecommendedJavaTypeMapping(*)
 - category: mandatory
   customVariables:
   - name: className

--- a/default/generated/eap8/152-hibernate-search-6.1.windup.yaml
+++ b/default/generated/eap8/152-hibernate-search-6.1.windup.yaml
@@ -183,7 +183,7 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString.fromJSon*
+        pattern: org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString.fromJSon(*)
 - category: mandatory
   customVariables: []
   description: FieldPaths#absolutize(String, String, String) has been removed
@@ -233,7 +233,7 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor.createIndexingPlan*
+        pattern: org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor.createIndexingPlan(*)
 - category: mandatory
   customVariables: []
   description: IndexIndexingPlan#executeAndReport has changed
@@ -258,7 +258,7 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan.executeAndReport*
+        pattern: org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan.executeAndReport(*)
 - category: mandatory
   customVariables: []
   description: IndexSchemaObjectNodeBuilder has changed

--- a/default/generated/eap8/154-hibernate6.windup.yaml
+++ b/default/generated/eap8/154-hibernate6.windup.yaml
@@ -248,10 +248,10 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: jakarta.persistence.Query.getResultStream*
+        pattern: jakarta.persistence.Query.getResultStream(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: org.hibernate.query.Query.stream*
+        pattern: org.hibernate.query.Query.stream(*)
 - category: mandatory
   customVariables: []
   description: The signature of the Interceptor#onSave method has been changed
@@ -275,7 +275,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.Interceptor.onSave*
+      pattern: org.hibernate.Interceptor.onSave(*)
 - category: mandatory
   customVariables: []
   description: The contents of the loader.collection package have been restructured
@@ -475,7 +475,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: org.hibernate.query.Query.iterate*
+      pattern: org.hibernate.query.Query.iterate(*)
 - category: mandatory
   customVariables: []
   description: Using NativeQuery to call SQL functions and procedures is no longer

--- a/default/generated/eap8/155-jakarta-cdi.windup.yaml
+++ b/default/generated/eap8/155-jakarta-cdi.windup.yaml
@@ -19,7 +19,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.enterprise.inject.spi.Bean.isNullable*
+      pattern: javax.enterprise.inject.spi.Bean.isNullable(*)
 - category: mandatory
   customVariables: []
   description: Method jakarta.enterprise.inject.spi.BeanManager.createInjectionTarget(AnnotatedType)
@@ -44,7 +44,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: jakarta.enterprise.inject.spi.BeanManager.createInjectionTarget*
+      pattern: jakarta.enterprise.inject.spi.BeanManager.createInjectionTarget(*)
 - category: mandatory
   customVariables: []
   description: Method jakarta.enterprise.inject.spi.BeanManager.fireEvent(Object,
@@ -69,7 +69,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: jakarta.enterprise.inject.spi.BeanManager.fireEvent*
+      pattern: jakarta.enterprise.inject.spi.BeanManager.fireEvent(*)
 - category: potential
   customVariables: []
   description: Method javax.enterprise.inject.spi.BeforeBeanDiscovery.addAnnotatedType(AnnotatedType)
@@ -92,4 +92,4 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.enterprise.inject.spi.BeforeBeanDiscovery.addAnnotatedType*
+      pattern: javax.enterprise.inject.spi.BeforeBeanDiscovery.addAnnotatedType(*)

--- a/default/generated/eap8/156-jakarta-el.windup.yaml
+++ b/default/generated/eap8/156-jakarta-el.windup.yaml
@@ -16,7 +16,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.el.MethodExpression.isParmetersProvided*
+      pattern: javax.el.MethodExpression.isParmetersProvided(*)
 - category: mandatory
   customVariables: []
   description: The incorrectly spelled jakarta.el.MethodExpression.isParmetersProvided()
@@ -35,4 +35,4 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: jakarta.el.MethodExpression.isParmetersProvided*
+      pattern: jakarta.el.MethodExpression.isParmetersProvided(*)

--- a/default/generated/eap8/159-jakarta-soap.windup.yaml
+++ b/default/generated/eap8/159-jakarta-soap.windup.yaml
@@ -15,7 +15,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.xml.soap.SOAPElementFactory.newInstance*
+      pattern: javax.xml.soap.SOAPElementFactory.newInstance(*)
 - category: mandatory
   customVariables: []
   description: javax.xml.soap.SOAPElementFactory.create() must be replaced
@@ -33,4 +33,4 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.xml.soap.SOAPElementFactory.create*
+      pattern: javax.xml.soap.SOAPElementFactory.create(*)

--- a/default/generated/eap8/166-javax-to-jakarta-servlet.windup.yaml
+++ b/default/generated/eap8/166-javax-to-jakarta-servlet.windup.yaml
@@ -287,7 +287,7 @@
   when:
     java.referenced:
       location: CONSTRUCTOR_CALL
-      pattern: javax.servlet.UnavailableException(int, javax.servlet.Servlet*
+      pattern: javax.servlet.UnavailableException(int, javax.servlet.Servlet, java.lang.String)
 - category: mandatory
   customVariables: []
   description: Method isRequestedSessionIdFromUrl in javax.servlet.http.HttpServletRequest

--- a/default/generated/eap8/166-javax-to-jakarta-servlet.windup.yaml
+++ b/default/generated/eap8/166-javax-to-jakarta-servlet.windup.yaml
@@ -54,7 +54,7 @@
         pattern: javax.servlet.http.HttpSessionContext
     - java.referenced:
         location: METHOD_CALL
-        pattern: javax.servlet.http.HttpSession.getSessionContext*
+        pattern: javax.servlet.http.HttpSession.getSessionContext(*)
 - category: mandatory
   customVariables: []
   description: The javax.servlet.http.HttpUtils utility class has been removed
@@ -102,7 +102,7 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: javax.servlet.ServletContext.getServlet*
+        pattern: javax.servlet.ServletContext.getServlet(*)
 - category: mandatory
   customVariables: []
   description: Method getServlets in javax.servlet.ServletContext has been removed
@@ -125,7 +125,7 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: javax.servlet.ServletContext.getServlets*
+        pattern: javax.servlet.ServletContext.getServlets(*)
 - category: mandatory
   customVariables: []
   description: Method getServletNames in javax.servlet.ServletContext has been removed
@@ -148,7 +148,7 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: javax.servlet.ServletContext.getServletNames*
+        pattern: javax.servlet.ServletContext.getServletNames(*)
 - category: mandatory
   customVariables: []
   description: Method log(Exception, String) in javax.servlet.ServletContext has been
@@ -195,7 +195,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.servlet.ServletRequest.getRealPath*
+      pattern: javax.servlet.ServletRequest.getRealPath(*)
 - category: mandatory
   customVariables: []
   description: Method in javax.servlet.ServletRequestWrapper has been removed
@@ -239,7 +239,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.servlet.UnavailableException.getServlet*
+      pattern: javax.servlet.UnavailableException.getServlet(*)
 - category: mandatory
   customVariables: []
   description: Constructor UnavailableException(Servlet, String) in javax.servlet.UnavailableException
@@ -311,7 +311,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.servlet.http.HttpServletRequest.isRequestedSessionIdFromUrl*
+      pattern: javax.servlet.http.HttpServletRequest.isRequestedSessionIdFromUrl(*)
 - category: mandatory
   customVariables: []
   description: Method isRequestedSessionIdFromUrl in javax.servlet.http.HttpServletRequestWrapper
@@ -335,7 +335,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.servlet.http.HttpServletRequestWrapper.isRequestedSessionIdFromUrl*
+      pattern: javax.servlet.http.HttpServletRequestWrapper.isRequestedSessionIdFromUrl(*)
 - category: mandatory
   customVariables: []
   description: Method encodeUrl in javax.servlet.http.HttpServletResponse has been
@@ -496,7 +496,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.servlet.http.HttpSession.getValue*
+      pattern: javax.servlet.http.HttpSession.getValue(*)
 - category: mandatory
   customVariables: []
   description: Method getValueNames in javax.servlet.http.HttpSession has been removed
@@ -519,7 +519,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.servlet.http.HttpSession.getValueNames*
+      pattern: javax.servlet.http.HttpSession.getValueNames(*)
 - category: mandatory
   customVariables: []
   description: Method putValue in javax.servlet.http.HttpSession has been removed
@@ -542,7 +542,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.servlet.http.HttpSession.putValue*
+      pattern: javax.servlet.http.HttpSession.putValue(*)
 - category: mandatory
   customVariables: []
   description: Method removeValue in javax.servlet.http.HttpSession has been removed
@@ -565,7 +565,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.servlet.http.HttpSession.removeValue*
+      pattern: javax.servlet.http.HttpSession.removeValue(*)
 - category: potential
   customVariables: []
   description: web.xml element references a javax-prefixed class name

--- a/default/generated/fuse/183-sonic-esb.windup.yaml
+++ b/default/generated/fuse/183-sonic-esb.windup.yaml
@@ -122,7 +122,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: com.sonicsw.xq.XQInitContext.getParameters*
+      pattern: com.sonicsw.xq.XQInitContext.getParameters(*)
 - category: mandatory
   customVariables: []
   description: Call of com.sonicsw.xq.XQParameters.getParameter
@@ -140,7 +140,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: com.sonicsw.xq.XQParameters.getParameter*
+      pattern: com.sonicsw.xq.XQParameters.getParameter(*)
 - category: mandatory
   customVariables: []
   description: Reference to com.sonicsw.xq.XQParameters
@@ -222,7 +222,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: com.sonicsw.xq.XQMessage.getHeaderValue*
+      pattern: com.sonicsw.xq.XQMessage.getHeaderValue(*)
 - category: mandatory
   customVariables: []
   description: Call of com.sonicsw.xq.XQMessage.setHeaderValue
@@ -239,7 +239,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: com.sonicsw.xq.XQMessage.setHeaderValue*
+      pattern: com.sonicsw.xq.XQMessage.setHeaderValue(*)
 - category: mandatory
   customVariables: []
   description: Call of com.sonicsw.xq.XQMessage.getHeaderNames
@@ -256,7 +256,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: com.sonicsw.xq.XQMessage.getHeaderNames*
+      pattern: com.sonicsw.xq.XQMessage.getHeaderNames(*)
 - category: mandatory
   customVariables: []
   description: Reference to com.sonicsw.xq.XQPart
@@ -294,7 +294,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: com.sonicsw.xq.XQMessage.getPartCount*
+      pattern: com.sonicsw.xq.XQMessage.getPartCount(*)
 - category: mandatory
   customVariables: []
   description: Call of com.sonicsw.xq.XQMessage.getPart
@@ -311,7 +311,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: com.sonicsw.xq.XQMessage.getPart*
+      pattern: com.sonicsw.xq.XQMessage.getPart(*)
 - category: mandatory
   customVariables: []
   description: Reference to com.sonicsw.xq.XQLog
@@ -377,7 +377,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: com.sonicsw.xq.XQMessage.getCorrelationId*
+      pattern: com.sonicsw.xq.XQMessage.getCorrelationId(*)
 - category: mandatory
   customVariables: []
   description: Call of com.sonicsw.xq.XQAddressFactory.createEndpointAddress
@@ -399,7 +399,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: com.sonicsw.xq.XQAddressFactory.createEndpointAddress*
+      pattern: com.sonicsw.xq.XQAddressFactory.createEndpointAddress(*)
 - category: mandatory
   customVariables: []
   description: Call of com.sonicsw.xq.XQServiceContext.addOutgoing
@@ -420,7 +420,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: com.sonicsw.xq.XQServiceContext.addOutgoing*
+      pattern: com.sonicsw.xq.XQServiceContext.addOutgoing(*)
 - category: mandatory
   customVariables: []
   description: Reference to com.sonicsw.xq.XQEnvelope
@@ -458,4 +458,4 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: com.sonicsw.xq.XQEnvelope.getMessage*
+      pattern: com.sonicsw.xq.XQEnvelope.getMessage(*)

--- a/default/generated/openjdk11/191-java-removals.windup.yaml
+++ b/default/generated/openjdk11/191-java-removals.windup.yaml
@@ -18,10 +18,10 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.Thread.stop({.+})
+        pattern: java.lang.Thread.stop(Throwable)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.Thread.destroy*
+        pattern: java.lang.Thread.destroy(*)
 - category: mandatory
   customVariables: []
   description: sun.reflect.Reflection class was deprecated in Java 9
@@ -47,7 +47,7 @@
         pattern: sun.reflect.Reflection*
     - java.referenced:
         location: METHOD_CALL
-        pattern: sun.reflect.Reflection*
+        pattern: sun.reflect.Reflection(*)
 - category: mandatory
   customVariables: []
   description: sun.reflect.CallerSensitive annotation was deprecated in Java 9
@@ -152,7 +152,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: java.lang.SecurityManager.checkMemberAccess*
+      pattern: java.lang.SecurityManager.checkMemberAccess(*)
 - category: mandatory
   customVariables: []
   description: The java.util.logging.LogManager.addPropertyChangeListener() method
@@ -174,7 +174,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: java.util.logging.LogManager.addPropertyChangeListener*
+      pattern: java.util.logging.LogManager.addPropertyChangeListener(*)
 - category: mandatory
   customVariables: []
   description: The java.util.logging.LogManager.removePropertyChangeListener() method
@@ -196,7 +196,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: java.util.logging.LogManager.removePropertyChangeListener*
+      pattern: java.util.logging.LogManager.removePropertyChangeListener(*)
 - category: mandatory
   customVariables: []
   description: Property listener methods on `Pack200.Packer` and `Pack200.Unpacker`
@@ -221,16 +221,16 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.util.jar.Pack200.Packer.addPropertyChangeListener*
+        pattern: java.util.jar.Pack200.Packer.addPropertyChangeListener(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.util.jar.Pack200.Packer.removePropertyChangeListener*
+        pattern: java.util.jar.Pack200.Packer.removePropertyChangeListener(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.util.jar.Pack200.Unpacker.addPropertyChangeListener*
+        pattern: java.util.jar.Pack200.Unpacker.addPropertyChangeListener(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.util.jar.Pack200.Unpacker.removePropertyChangeListener*
+        pattern: java.util.jar.Pack200.Unpacker.removePropertyChangeListener(*)
 - category: mandatory
   customVariables:
   - name: methodName
@@ -318,10 +318,10 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.System.runFinalizersOnExit*
+        pattern: java.lang.System.runFinalizersOnExit(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.Runtime.runFinalizersOnExit*
+        pattern: java.lang.Runtime.runFinalizersOnExit(*)
 - category: mandatory
   customVariables: []
   description: The `java.awt.Font.getPeer()` and `java.awt.Component.getPeer()` methods
@@ -347,10 +347,10 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.awt.Font.getPeer*
+        pattern: java.awt.Font.getPeer(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.awt.Component.getPeer*
+        pattern: java.awt.Component.getPeer(*)
 - category: potential
   customVariables: []
   description: Changes in ClassLoader hierarchy in JDK 11 may impact code

--- a/default/generated/openjdk17/197-security-manager-deprecation.windup.yaml
+++ b/default/generated/openjdk17/197-security-manager-deprecation.windup.yaml
@@ -61,7 +61,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: java.lang.System.(getSecurityManager|setSecurityManager)*
+      pattern: java.lang.System.(getSecurityManager|setSecurityManager)(*)
 - category: mandatory
   customVariables: []
   description: java.lang.Thread.checkAccess method has been deprecated
@@ -80,7 +80,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: java.lang.Thread.checkAccess*
+      pattern: java.lang.Thread.checkAccess(*)
 - category: mandatory
   customVariables: []
   description: java.lang.ThreadGroup.checkAccess method has been deprecated
@@ -99,7 +99,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: java.lang.ThreadGroup.checkAccess*
+      pattern: java.lang.ThreadGroup.checkAccess(*)
 - category: mandatory
   customVariables: []
   description: java.util.logging.LogManager.checkAccess method has been deprecated
@@ -118,7 +118,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: java.util.logging.LogManager.checkAccess*
+      pattern: java.util.logging.LogManager.checkAccess(*)
 - category: mandatory
   customVariables:
   - name: methodNames

--- a/default/generated/openjdk21/198-deprecation-openjdk18.windup.yaml
+++ b/default/generated/openjdk21/198-deprecation-openjdk18.windup.yaml
@@ -14,7 +14,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: javax.security.auth.Subject.doAs*
+      pattern: javax.security.auth.Subject.doAs(*)
 - category: mandatory
   customVariables: []
   description: Deprecated method in JDK 18 for removal in future release
@@ -31,4 +31,4 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: java.lang.Thread.stop*
+      pattern: java.lang.Thread.stop(*)

--- a/default/generated/openjdk21/199-deprecation-openjdk19.windup.yaml
+++ b/default/generated/openjdk21/199-deprecation-openjdk19.windup.yaml
@@ -25,13 +25,13 @@
         pattern: javax.swing.plaf.basic.BasicScrollPaneUI.VSBChangeListener
     - java.referenced:
         location: METHOD_CALL
-        pattern: javax.swing.plaf.basic.BasicDirectoryModel.intervalAdded*
+        pattern: javax.swing.plaf.basic.BasicDirectoryModel.intervalAdded(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: javax.swing.plaf.basic.BasicDirectoryModel.intervalRemoved*
+        pattern: javax.swing.plaf.basic.BasicDirectoryModel.intervalRemoved(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: javax.swing.plaf.basic.BasicDirectoryModel.lt*
+        pattern: javax.swing.plaf.basic.BasicDirectoryModel.lt(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: javax.swing.plaf.basic.BasicToolBarUI.createFloatingFrame*
+        pattern: javax.swing.plaf.basic.BasicToolBarUI.createFloatingFrame(*)

--- a/default/generated/openjdk21/203-finalization-deprecation.windup.yaml
+++ b/default/generated/openjdk21/203-finalization-deprecation.windup.yaml
@@ -42,7 +42,7 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.Runtime.runFinalization*
+        pattern: java.lang.Runtime.runFinalization(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.System.runFinalization*
+        pattern: java.lang.System.runFinalization(*)

--- a/default/generated/openjdk21/204-removed-apis.windup.yaml
+++ b/default/generated/openjdk21/204-removed-apis.windup.yaml
@@ -14,13 +14,13 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.awt.color.ICC_Profile.finalize*
+        pattern: java.awt.color.ICC_Profile.finalize(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.awt.image.ColorModel.finalize*
+        pattern: java.awt.image.ColorModel.finalize(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.awt.image.IndexColorModel.finalize*
+        pattern: java.awt.image.IndexColorModel.finalize(*)
 - category: mandatory
   customVariables: []
   description: Method java.lang.ThreadGroup.allowThreadSuspension() has been removed
@@ -36,7 +36,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: java.lang.ThreadGroup.allowThreadSuspension*
+      pattern: java.lang.ThreadGroup.allowThreadSuspension(*)
 - category: mandatory
   customVariables: []
   description: Method java.lang.Compiler has been removed

--- a/default/generated/openjdk21/205-utf-8-by-default.windup.yaml
+++ b/default/generated/openjdk21/205-utf-8-by-default.windup.yaml
@@ -60,7 +60,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: java.net.URLEncoder.encode*
+      pattern: java.net.URLEncoder.encode(*)
 - category: potential
   customVariables: []
   description: The java.net.URLDecoder.decode method uses UTF-8 by default
@@ -79,4 +79,4 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: java.net.URLDecoder.decode*
+      pattern: java.net.URLDecoder.decode(*)

--- a/default/generated/openjdk7/206-oracle2openjdk.rhamt.yaml
+++ b/default/generated/openjdk7/206-oracle2openjdk.rhamt.yaml
@@ -147,10 +147,10 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.security.KeyPairGenerator.getInstance*
+        pattern: java.security.KeyPairGenerator.getInstance(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: javax.crypto.KeyAgreement.getInstance*
+        pattern: javax.crypto.KeyAgreement.getInstance(*)
     - java.referenced:
         location: CONSTRUCTOR_CALL
         pattern: java.security.spec.EC*
@@ -162,7 +162,7 @@
         pattern: java.security.spec.EC*
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.security.spec.EC*
+        pattern: java.security.spec.EC(*)
     - java.referenced:
         location: VARIABLE_DECLARATION
         pattern: java.security.spec.EC*
@@ -177,7 +177,7 @@
         pattern: java.security.spec.EllipticCurve*
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.security.spec.EllipticCurve*
+        pattern: java.security.spec.EllipticCurve(*)
     - java.referenced:
         location: VARIABLE_DECLARATION
         pattern: java.security.spec.EllipticCurve*

--- a/default/generated/openliberty/208-liberty-websphere-unavailable-technologies.windup.yaml
+++ b/default/generated/openliberty/208-liberty-websphere-unavailable-technologies.windup.yaml
@@ -407,10 +407,10 @@
     or:
     - java.referenced:
         location: METHOD_CALL
-        pattern: com.ibm.websphere.management.AdminService.getProcessName*
+        pattern: com.ibm.websphere.management.AdminService.getProcessName(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: com.ibm.ejs.ras.RasHelper.getServerName*
+        pattern: com.ibm.ejs.ras.RasHelper.getServerName(*)
     - java.referenced:
         location: METHOD_CALL
         pattern: com.ibm.websphere.runtime.ServerName.(getDisplayName|getFullName)*
@@ -1065,7 +1065,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: com.ibm.websphere.security.WSSecurityHelper.(getFirstCaller|getFirstServer|getCallerList|getServerList|getPropagationAttributes|addPropagationAttribute|convertCookieStringToBytes|revokeSSOCookiesForPortlets)*
+      pattern: com.ibm.websphere.security.WSSecurityHelper.(getFirstCaller|getFirstServer|getCallerList|getServerList|getPropagationAttributes|addPropagationAttribute|convertCookieStringToBytes|revokeSSOCookiesForPortlets)(*)
 - category: mandatory
   customVariables: []
   description: The WebSphere Remote Request Dispatcher (RRD) SPIs are unavailable
@@ -1134,7 +1134,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: com.ibm.websphere.security.WSSecurityHelper.revokeSSOCookies*
+      pattern: com.ibm.websphere.security.WSSecurityHelper.revokeSSOCookies(*)
 - category: mandatory
   customVariables: []
   description: Do not use the WSSecurityHelper getLTPACookieFromSSOToken method
@@ -1186,7 +1186,7 @@
   when:
     java.referenced:
       location: METHOD_CALL
-      pattern: com.ibm.websphere.security.WSSecurityHelper.getLTPACookieFromSSOToken*
+      pattern: com.ibm.websphere.security.WSSecurityHelper.getLTPACookieFromSSOToken(*)
 - category: optional
   customVariables: []
   description: Some WebSphere z/OS Optimized Local Adapters APIs are unavailable

--- a/default/generated/technology-usage/36-connect-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/36-connect-technology-usage.windup.yaml
@@ -31,10 +31,10 @@
         pattern: java.lang.System.(load|loadLibrary|mapLibraryName)*
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.Runtime.load*
+        pattern: java.lang.Runtime.load(*)
     - java.referenced:
         location: METHOD_CALL
-        pattern: java.lang.Runtime.loadLibrary*
+        pattern: java.lang.Runtime.loadLibrary(*)
 - customVariables: []
   description: JNA usage
   labels:
@@ -59,7 +59,7 @@
         pattern: com.sun.jna*
     - java.referenced:
         location: METHOD_CALL
-        pattern: com.sun.jna*
+        pattern: com.sun.jna(*)
     - java.referenced:
         location: VARIABLE_DECLARATION
         pattern: com.sun.jna*


### PR DESCRIPTION
- Improves false positives in https://github.com/konveyor/analyzer-lsp/issues/656
- Not all `METHOD_CALL`s have been changed, only simple ones looking for empty signatures or not caring about the signature.

Improves numbers marginally:
- Without:
```
------------------------------------------------------------
  Rules Summary:      1444/1977 (73.04%) PASSED
  Test Cases Summary: 1924/2505 (76.81%) PASSED
------------------------------------------------------------
```
- With:
```
------------------------------------------------------------
  Rules Summary:      1445/1977 (73.09%) PASSED
  Test Cases Summary: 1925/2505 (76.85%) PASSED
------------------------------------------------------------
```