### PR TITLE
Add empty description to discovery rules

### DIFF
--- a/default/generated/technology-usage/11-non-xml-rules-technology-usage.rhamt.yaml
+++ b/default/generated/technology-usage/11-non-xml-rules-technology-usage.rhamt.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: Non-XML EJB
   labels:
   - konveyor.io/include=always
   links: []
@@ -71,6 +72,7 @@
     builtin.hasTags:
     - JDBC
 - customVariables: []
+  description: Non-XML JPA
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/22-javaee-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/22-javaee-technology-usage.windup.yaml
@@ -56,6 +56,7 @@
     builtin.hasTags:
     - Java EE Batch
 - customVariables: []
+  description: JavaEE javax
   labels:
   - konveyor.io/include=always
   links: []
@@ -71,6 +72,7 @@
         location: PACKAGE
         pattern: javax.inject*
 - customVariables: []
+  description: JavaEE Jakarta
   labels:
   - konveyor.io/include=always
   links: []
@@ -86,6 +88,7 @@
         location: PACKAGE
         pattern: jakarta.inject*
 - customVariables: []
+  description: JavaEE
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/34-database-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/34-database-technology-usage.windup.yaml
@@ -25,6 +25,7 @@
       location: ANNOTATION
       pattern: javax.annotation.sql.DataSourceDefinition
 - customVariables: []
+  description: JPA Entities
   labels:
   - konveyor.io/include=always
   links: []
@@ -45,6 +46,7 @@
         filePattern: .*\.xml
         pattern: https://jakarta.ee/xml/ns/persistence
 - customVariables: []
+  description: JPA Queries
   labels:
   - konveyor.io/include=always
   links: []
@@ -86,6 +88,7 @@
         location: ANNOTATION
         pattern: jakarta.persistence.DiscriminatorValue
 - customVariables: []
+  description: Persistence Units
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/36-connect-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/36-connect-technology-usage.windup.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: Java Connect
   labels:
   - konveyor.io/include=always
   links: []


### PR DESCRIPTION
Some rules are missing desciptions which doesn't look good in e.g. static-report, adding those. Related to complete-duke.zip sample app.

Fixes: https://issues.redhat.com/browse/MTA-3212