### PR TITLE
:sparkles: Rule for @Async detection

### DIFF
--- a/default/generated/spring-framework/spring-framework-5.x-to-6.0-core-container.yaml
+++ b/default/generated/spring-framework/spring-framework-5.x-to-6.0-core-container.yaml
@@ -20,3 +20,24 @@
   links:
   - title: 'Spring 6.0 migration guide'
     url: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.0-Release-Notes#core-container
+
+- ruleID: spring-framework-5.x-to-6.0-core-container-00010
+  category: potential
+  effort: 2
+  labels:
+    - konveyor.io/source=spring5
+    - konveyor.io/target=spring6+
+  when:
+    java.referenced:
+      pattern: org.springframework.scheduling.annotation.Async
+      location: ANNOTATION
+  description: Methods annotated with @Async must return either Future or void
+  message: |
+    Methods annotated with @Async must return either Future or void. This has long been documented but is now also
+    actively checked and enforced, with an exception thrown for any other return type.
+    
+    If your @Async annotated method does not return `Future` or `void`, please change its signature.
+  links:
+    - title: 'Spring 6.0 migration guide'
+      url: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.0-Release-Notes#core-container
+

--- a/default/generated/spring-framework/tests/data/core-container/src/main/java/org/konveyor/Main.java
+++ b/default/generated/spring-framework/tests/data/core-container/src/main/java/org/konveyor/Main.java
@@ -1,12 +1,13 @@
 package org.konveyor;
 
 import org.konveyor.beans.Bean;
+import org.springframework.beans.BeanInfoFactory;
+import org.springframework.beans.SimpleBeanInfoFactory;
+import org.springframework.scheduling.annotation.Async;
 
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
-
-import org.springframework.beans.BeanInfoFactory;
-import org.springframework.beans.SimpleBeanInfoFactory;
+import java.util.concurrent.RunnableFuture;
 
 public class Main {
 
@@ -14,6 +15,17 @@ public class Main {
         BeanInfoFactory factory = new SimpleBeanInfoFactory();
         BeanInfo beanInfo = factory.getBeanInfo(Bean.class);
         System.out.println(beanInfo.getBeanDescriptor());
+
+
+    }
+
+    @Async
+    public RunnableFuture<String> correctAsyncMethod(String param) {
+        return null;
+    }
+
+    @Async
+    public void correctAsyncMethod2(String param) {
     }
 
 }

--- a/default/generated/spring-framework/tests/spring-framework-5.x-to-6.0-core-container.test.yaml
+++ b/default/generated/spring-framework/tests/spring-framework-5.x-to-6.0-core-container.test.yaml
@@ -10,3 +10,10 @@ tests:
       mode: "source-only"
     hasIncidents:
       exactly: 2
+- ruleID: spring-framework-5.x-to-6.0-core-container-00010
+  testCases:
+    - name: tc-1
+      analysisParams:
+        mode: "source-only"
+      hasIncidents:
+        exactly: 2


### PR DESCRIPTION
Ideally we would want to look for methods that are annotated with `@Async` and **don't** return `void` or `Future`, but it is not possible at the moment. We can look for methods that *do* return particular types, but not for methods that return "anything _but_ a type". Also, negating the condition would only tell us that there are no methods that return `void` or `Future`, but that does not guarantee that there are more methods which do return something else.

See https://github.com/konveyor/rulesets/issues/141