### PR TITLE
Rule for ListenableFuture deprecation in Spring6+

### DIFF
--- a/default/generated/spring-framework/spring-framework-5.x-to-6.0-core-container.yaml
+++ b/default/generated/spring-framework/spring-framework-5.x-to-6.0-core-container.yaml
@@ -40,4 +40,53 @@
   links:
     - title: 'Spring 6.0 migration guide'
       url: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.0-Release-Notes#core-container
+      
+- ruleID: spring-framework-5.x-to-6.0-core-container-00020
+  category: potential
+  effort: 3
+  labels:
+  - konveyor.io/source=spring5
+  - konveyor.io/target=spring6+
+  when:
+    java.referenced:
+      pattern: org.springframework.util.concurrent.ListenableFuture*
+      location: IMPORT
+  description: ListenableFuture and related types are deprecated from Spring Framework 6.0.  
+  message: |
+    Spring Framework 6.0 has deprecated support for ListenableFuture and related types (ListenableFutureCallback, SettableListenableFuture, etc.)
+    The reason for deprecation is the introduction of CompletableFuture in Java 8, which offers a richer set of features and better integration with the Java ecosystem.
+    java.util.concurrent.CompletableFuture is now the recommended way to handle asynchronous operations in Spring applications.
+  Example:
+    
+        import java.util.concurrent.CompletableFuture;
+
+        public class CompletableFutureCallback {
+            public static void main(String[] args) {
+              CompletableFuture<String> completableFuture = new CompletableFuture<>();
+              Runnable runnable = callUpstreamWS(completableFuture);
+              completableFuture.whenComplete((res, error) -> {
+              if (error != null) {
+              // Handle exception
+              } else if (res != null) {
+              // Process data
+              }
+              });
+              new Thread(runnable).start();
+            }
+
+            private static Runnable callUpstreamWS(CompletableFuture<String> completableFuture) {
+                  return () -> {
+                    try {
+                    //Upstream call
+                    Thread.sleep(5000);
+                    } catch (InterruptedException e) {
+                    e.printStackTrace();
+                    }
+                    completableFuture.complete("ws.data");
+                    };
+            }
+        }
+  links:
+  - title: 'Spring 6.0 migration guide'
+    url: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.0-Release-Notes#core-container
 

--- a/default/generated/spring-framework/spring-framework-5.x-to-6.0-core-container.yaml
+++ b/default/generated/spring-framework/spring-framework-5.x-to-6.0-core-container.yaml
@@ -42,8 +42,8 @@
       url: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.0-Release-Notes#core-container
       
 - ruleID: spring-framework-5.x-to-6.0-core-container-00020
-  category: potential
-  effort: 3
+  category: optional
+  effort: 2
   labels:
   - konveyor.io/source=spring5
   - konveyor.io/target=spring6+
@@ -51,41 +51,83 @@
     java.referenced:
       pattern: org.springframework.util.concurrent.ListenableFuture*
       location: IMPORT
-  description: ListenableFuture and related types are deprecated since Spring Framework 6.0.  
+  description: ListenableFuture and related types are deprecated since Spring Framework 6.0  
   message: |
     Spring Framework 6.0 has deprecated support for ListenableFuture and related types (ListenableFutureCallback, SettableListenableFuture, etc.)
     The reason for deprecation is the introduction of CompletableFuture in Java 8, which offers a richer set of features and better integration with the Java ecosystem.
     java.util.concurrent.CompletableFuture is now the recommended way to handle asynchronous operations in Spring applications.
-  Example:
     
-        import java.util.concurrent.CompletableFuture;
+    An example of a migration would be:
+    
+    Before migration:
+    ```
+        import org.springframework.util.concurrent.ListenableFuture;
+        import org.springframework.util.concurrent.ListenableFutureCallback;
+        import org.springframework.util.concurrent.SettableListenableFuture;
 
-        public class CompletableFutureCallback {
+        public class ListenableFutureExample {
+
             public static void main(String[] args) {
-              CompletableFuture<String> completableFuture = new CompletableFuture<>();
-              Runnable runnable = callUpstreamWS(completableFuture);
-              completableFuture.whenComplete((res, error) -> {
-              if (error != null) {
-              // Handle exception
-              } else if (res != null) {
-              // Process data
-              }
-              });
-              new Thread(runnable).start();
-            }
+                SettableListenableFuture<String> future = new SettableListenableFuture<>();
 
-            private static Runnable callUpstreamWS(CompletableFuture<String> completableFuture) {
-                  return () -> {
-                    try {
-                    //Upstream call
-                    Thread.sleep(5000);
-                    } catch (InterruptedException e) {
-                    e.printStackTrace();
+                future.addCallback(new ListenableFutureCallback<String>() {
+                    @Override
+                    public void onSuccess(String result) {
+                        System.out.println("Success: " + result);
                     }
-                    completableFuture.complete("ws.data");
-                    };
+
+                    @Override
+                    public void onFailure(Throwable ex) {
+                        System.out.println("Failure: " + ex.getMessage());
+                    }
+                });
+
+                // Simulate asynchronous operation
+                new Thread(() -> {
+                    try {
+                        Thread.sleep(1000);
+                        future.set("Hello, World!");
+                    } catch (InterruptedException e) {
+                        future.setException(e);
+                    }
+                }).start();
             }
         }
+        
+    ```
+    
+    After migration:
+    ```
+        import java.util.concurrent.CompletableFuture;
+
+        public class CompletableFutureExample {
+          public static void main(String[] args) {
+            CompletableFuture<String> future = new CompletableFuture<>();
+
+            future.whenComplete((result, ex) -> {
+              if (ex != null) {
+                System.out.println("Failure: " + ex.getMessage());
+              } else if (result != null) {
+                System.out.println("Success: " + result);
+              }
+            });
+
+            // Simulate asynchronous operation
+            new Thread(() -> {
+              try {
+                // Thread.currentThread().interrupt();
+                Thread.sleep(1000);
+                future.complete("Hello, World!");
+              } catch (InterruptedException e) {
+                future.completeExceptionally(e);
+              }
+            }).start();
+          }
+
+        }
+
+    ```    
+
   links:
   - title: 'Spring 6.0 migration guide'
     url: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.0-Release-Notes#core-container

--- a/default/generated/spring-framework/spring-framework-5.x-to-6.0-core-container.yaml
+++ b/default/generated/spring-framework/spring-framework-5.x-to-6.0-core-container.yaml
@@ -51,7 +51,7 @@
     java.referenced:
       pattern: org.springframework.util.concurrent.ListenableFuture*
       location: IMPORT
-  description: ListenableFuture and related types are deprecated from Spring Framework 6.0.  
+  description: ListenableFuture and related types are deprecated since Spring Framework 6.0.  
   message: |
     Spring Framework 6.0 has deprecated support for ListenableFuture and related types (ListenableFutureCallback, SettableListenableFuture, etc.)
     The reason for deprecation is the introduction of CompletableFuture in Java 8, which offers a richer set of features and better integration with the Java ecosystem.

--- a/default/generated/spring-framework/tests/data/core-container/src/main/java/org/konveyor/ListenableFutureTest.java
+++ b/default/generated/spring-framework/tests/data/core-container/src/main/java/org/konveyor/ListenableFutureTest.java
@@ -1,0 +1,34 @@
+package org.konveyor;
+
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureCallback;
+import org.springframework.util.concurrent.SettableListenableFuture;
+
+public class ListenableFutureTest {
+
+    public static void main(String[] args) {
+        SettableListenableFuture<String> future = new SettableListenableFuture<>();
+
+        future.addCallback(new ListenableFutureCallback<String>() {
+            @Override
+            public void onSuccess(String result) {
+                System.out.println("Success: " + result);
+            }
+
+            @Override
+            public void onFailure(Throwable ex) {
+                System.out.println("Failure: " + ex.getMessage());
+            }
+        });
+
+        // Simulate asynchronous operation
+        new Thread(() -> {
+            try {
+                Thread.sleep(1000);
+                future.set("Hello, World!");
+            } catch (InterruptedException e) {
+                future.setException(e);
+            }
+        }).start();
+    }
+}

--- a/default/generated/spring-framework/tests/spring-framework-5.x-to-6.0-core-container.test.yaml
+++ b/default/generated/spring-framework/tests/spring-framework-5.x-to-6.0-core-container.test.yaml
@@ -17,3 +17,10 @@ tests:
         mode: "source-only"
       hasIncidents:
         exactly: 2
+- ruleID: spring-framework-5.x-to-6.0-core-container-00020
+  testCases:
+    - name: tc-1
+      analysisParams:
+        mode: "source-only"
+      hasIncidents:
+        exactly: 2


### PR DESCRIPTION
Create rules for deprecated ListenableFuture
[#140](https://github.com/konveyor/rulesets/issues/140)