### PR TITLE
Create rules for backwards compatibility with db specific error codes

### DIFF
--- a/default/generated/spring-framework/spring-framework-5.x-to-6.0-data-access.yaml
+++ b/default/generated/spring-framework/spring-framework-5.x-to-6.0-data-access.yaml
@@ -29,6 +29,71 @@
   - title: 'Spring 6.0 migration guide'
     url: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.0-Release-Notes#removed-apis
 
+- ruleID: spring-framework-5.x-to-6.0-data-access-00002
+  category: mandatory
+  effort: 1
+  labels:
+  - konveyor.io/source=spring5
+  - konveyor.io/target=spring6+
+  - konveyor.io/target=hibernate6+
+  when:
+    or:
+    - builtin.filecontent:
+        filePattern: (hibernate\.properties|persistence\.xml|cfg\.xml|application\.properties|application\.yaml)
+        pattern: hibernate.bytecode.provider=javassist
+    - as: hibernate_cfg
+      builtin.xml:
+        namespaces:
+          s: http://www.hibernate.org/xsd/hibernate-configuration
+        xpath: "/hibernate-configuration/session-factory/property[@name='hibernate.bytecode.provider' and text()='javassist']" 
+    - as: persistence_files
+      builtin.xml:
+        namespaces:
+          s: http://java.sun.com/xml/ns/persistence
+        xpath: /persistence/persistence-unit/properties/property[@name='hibernate.bytecode.provider' and @value='javassist']
+    - java.referenced:
+        pattern: org.hibernate.bytecode.javassist*
+    - builtin.filecontent:
+        filePattern: .*\.java
+        pattern: setProperty\(\"hibernate.bytecode.provider\", \"javassist\"\)
+  description: Javassist no longer supported
+  message: |
+    Explicit configuration of `hibernate.bytecode.provider=javassist` has been detected. Javassist is no longer supported by Hibernate 5.6 and later.
+
+    The simplest and recommended solution is to remove this property entirely. Hibernate will automatically use Byte Buddy, which is the current default.
+  links:
+  - title: 'Hibernate 5.6 migration guide - Javassist removed'
+    url: https://github.com/hibernate/hibernate-orm/blob/5.6/migration-guide.adoc#javassist-removed
+
+- ruleID: spring-framework-5.x-to-6.0-data-access-00003
+  category: potential
+  effort: 5
+  labels:
+  - konveyor.io/source=spring5
+  - konveyor.io/target=spring6+
+  - konveyor.io/target=hibernate6+
+  when:
+    and:
+      - or:  # Check for Hibernate annotations or clob fields
+        - java.referenced:
+            location: ANNOTATION
+            pattern: javax.persistence.Lob
+        - java.referenced:
+            location: FIELD
+            pattern: java.sql.Clob
+      - as: config_files # Check for PostgreSQL 8.1 dialect
+        builtin.filecontent:
+          filePattern: .*\.(java|properties|xml)
+          pattern: org.hibernate.dialect.PostgreSQL81Dialect
+  description: Changes to the DDL type for CLOB
+  message: |
+    Using `@Lob` or `java.sql.Clob` with PostgreSQL 8.1 dialect might require DDL type changes for CLOBs.
+
+    Consider reviewing DDL generation for CLOB columns and potential migration to 'oid' type if necessary.
+  links:
+  - title: 'Hibernate 5.6 migration guide - Changes to the DDL type for CLOB'
+    url: https://github.com/hibernate/hibernate-orm/blob/5.6/migration-guide.adoc#changes-to-the-ddl-type-for-clob-in-postgresql81dialect-and-its-subclasses
+
 - ruleID: spring-framework-5.x-to-6.0-data-access-00010
   category: mandatory
   effort: 3

--- a/default/generated/spring-framework/spring-framework-5.x-to-6.0-data-access.yaml
+++ b/default/generated/spring-framework/spring-framework-5.x-to-6.0-data-access.yaml
@@ -90,3 +90,45 @@
       url: https://eclipse.dev/eclipselink/downloads/previous_releases.php
     - title: 'Spring 6.0 migration guide'
       url: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.0-Release-Notes#removed-apis
+
+- ruleID: spring-framework-5.x-to-6.0-data-access-00030
+  category: mandatory
+  effort: 1
+  labels:
+  - konveyor.io/source=spring5
+  - konveyor.io/target=spring6+
+  when:
+    builtin.file:
+      pattern: sql-error-codes\.xml
+  description: Custom SQL Error Codes detected
+  message: |
+    sql-error-codes.xml file found. Consider re-enabling the legacy SQLErrorCodeSQLExceptionTranslator for database exception handling compatibility.
+
+    **Recommendation**:
+    Add the following bean definition to your Spring configuration:
+    ```
+      <bean id="legacySQLExceptionTranslator" class="org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator">
+        <constructor-arg ref="dataSource"/>
+      </bean>
+    ```
+    
+    or in Java config:
+    ```
+      @Bean
+      public SQLErrorCodeSQLExceptionTranslator legacySQLExceptionTranslator(DataSource dataSource) {
+          return new SQLErrorCodeSQLExceptionTranslator(dataSource);
+      }
+    ```
+
+    This explicitly re-enables the legacy translator, ensuring that the custom mappings are used. 
+    However, in the long term it is recommended to move away from this approach. 
+    Spring Framework 6 has a more refined and extensible system based on `SQLExceptionSubclassTranslator` and `SQLExceptionTranslator` implementations.
+
+    The long-term approach is to rely on Spring's built-in exception translation mechanism, which is more robust and requires less manual configuration.
+    This involves:
+    - `@Repository` **Annotation**: Ensure that your data access classes (DAOs or repositories) are annotated with `@Repository`. This annotation enables automatic exception translation.
+    - **Let Spring Handle It**: Remove the `sql-error-codes.xml` file and the explicit configuration of the `SQLErrorCodeSQLExceptionTranslator`. Spring will now use its more sophisticated `SQLExceptionTranslator` implementations (like `SQLExceptionSubclassTranslator`) to map `SQLExceptions` to `DataAccessExceptions`.
+
+  links:
+  - title: 'Spring 6.0 migration guide'
+    url: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.0-Release-Notes#data-access-and-transactions

--- a/default/generated/spring-framework/tests/data/data-access/src/main/java/com/example/HibernateClobTestApplication.java
+++ b/default/generated/spring-framework/tests/data/data-access/src/main/java/com/example/HibernateClobTestApplication.java
@@ -1,0 +1,66 @@
+package com.example.hibernateclobtest;
+
+import org.hibernate.annotations.DialectOverride;
+import org.hibernate.dialect.PostgreSQL81Dialect;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.*;
+import java.sql.Clob;
+
+@SpringBootApplication
+public class HibernateClobTestApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(HibernateClobTestApplication.class, args);
+    }
+}
+
+@Entity
+@DialectOverride.Overrides({
+        @DialectOverride(dialect = PostgreSQL81Dialect.class, overrides = {
+                @DialectOverride.Override(sqlType = "TEXT", type = String.class)
+        })
+})
+class MyEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Lob
+    private String largeText;
+
+    private Clob clobData;
+
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getLargeText() {
+        return largeText;
+    }
+
+    public void setLargeText(String largeText) {
+        this.largeText = largeText;
+    }
+
+    public Clob getClobData() {
+        return clobData;
+    }
+
+    public void setClobData(Clob clobData) {
+        this.clobData = clobData;
+    }
+}
+
+@Repository
+interface MyEntityRepository extends JpaRepository<MyEntity, Long> {
+
+}

--- a/default/generated/spring-framework/tests/data/data-access/src/main/java/com/example/config/HibernateConfig.java
+++ b/default/generated/spring-framework/tests/data/data-access/src/main/java/com/example/config/HibernateConfig.java
@@ -1,0 +1,54 @@
+package com.example.config;
+
+import org.apache.commons.dbcp2.BasicDataSource; // Or your preferred DataSource
+import org.hibernate.SessionFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.hibernate5.HibernateTransactionManager;
+import org.springframework.orm.hibernate5.LocalSessionFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.hibernate.bytecode.javassist.FieldHandled;
+
+import javax.sql.DataSource;
+import java.util.Properties;
+
+@Configuration
+@EnableTransactionManagement // Enable Spring's transaction management
+public class HibernateConfig {
+
+    @Bean
+    public LocalSessionFactoryBean sessionFactory() {
+        LocalSessionFactoryBean sessionFactoryBean = new LocalSessionFactoryBean();
+        sessionFactoryBean.setDataSource(dataSource()); // Set the DataSource
+        sessionFactoryBean.setPackagesToScan("com.example.entity"); // Package containing your entities
+
+        Properties properties = new Properties();
+        properties.setProperty("hibernate.dialect", "org.hibernate.dialect.H2Dialect"); // Database dialect
+        properties.setProperty("hibernate.bytecode.provider", "javassist"); // Javassist Bytecode provider (For Testing)
+        properties.setProperty("hibernate.show_sql", "true"); // Show SQL queries in the console (for debugging)
+        properties.setProperty("hibernate.format_sql", "true"); // Format SQL queries for better readability
+        //Add other hibernate properties as needed
+
+        sessionFactoryBean.setHibernateProperties(properties);
+
+        return sessionFactoryBean;
+    }
+
+    @Bean
+    public DataSource dataSource() {
+        BasicDataSource dataSource = new BasicDataSource();
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:mem:testdb"); // In-memory H2 database
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+        return dataSource;
+    }
+
+    @Bean
+    public PlatformTransactionManager hibernateTransactionManager() {
+        HibernateTransactionManager transactionManager = new HibernateTransactionManager();
+        transactionManager.setSessionFactory(sessionFactory().getObject());
+        return transactionManager;
+    }
+}

--- a/default/generated/spring-framework/tests/data/data-access/src/main/resources/META-INF/persistence.xml
+++ b/default/generated/spring-framework/tests/data/data-access/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,10 @@
+<persistence version="2.2"
+    xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
+    <persistence-unit name="myPersistenceUnit">
+        <properties>
+            <property name="hibernate.bytecode.provider" value="javassist" />
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/default/generated/spring-framework/tests/data/data-access/src/main/resources/application.properties
+++ b/default/generated/spring-framework/tests/data/data-access/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQL81Dialect
+spring.datasource.url=jdbc:postgresql://localhost:5432/your_database
+spring.datasource.driver-class-name=org.postgresql.Driver

--- a/default/generated/spring-framework/tests/data/data-access/src/main/resources/hibernate.cfg.xml
+++ b/default/generated/spring-framework/tests/data/data-access/src/main/resources/hibernate.cfg.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE hibernate-configuration PUBLIC
+"-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+"http://hibernate.sourceforge.net/hibernate-configuration-3.0.dtd">
+<hibernate-configuration>
+    <session-factory>
+        <property name="hibernate.cache.provider_class">org.hibernate.cache.EHCacheProvider</property>
+        <property name="hibernate.dialect">org.hibernate.dialect.MySQL5InnoDBDialect</property>
+        <property name="connection.pool_size">10</property>
+        <property name="show_sql">false</property>
+        <property name="hibernate.bytecode.provider">javassist</property>
+    </session-factory>
+</hibernate-configuration>

--- a/default/generated/spring-framework/tests/data/data-access/src/main/resources/hibernate.properties
+++ b/default/generated/spring-framework/tests/data/data-access/src/main/resources/hibernate.properties
@@ -1,0 +1,1 @@
+hibernate.bytecode.provider=javassist

--- a/default/generated/spring-framework/tests/data/data-access/src/main/resources/sql-error-codes.xml
+++ b/default/generated/spring-framework/tests/data/data-access/src/main/resources/sql-error-codes.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN"
+        "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
+
+<beans>
+
+    <bean id="MySQL" class="org.springframework.jdbc.support.SQLErrorCodes">
+        <property name="badSqlGrammarCodes">
+            <list>
+                <value>1054</value> <value>1064</value> </list>
+        </property>
+        <property name="invalidDataAccessCodes">
+            <list>
+                <value>1364</value> </list>
+        </property>
+        <property name="duplicateKeyCodes">
+            <list>
+                <value>1062</value> </list>
+        </property>
+        <property name="dataIntegrityViolationCodes">
+            <list>
+                <value>1451</value> <value>1452</value> </list>
+        </property>
+        <property name="dataAccessResourceFailureCodes">
+            <list>
+                <value>2006</value> <value>2013</value> </list>
+        </property>
+        <property name="cannotAcquireLockCodes">
+            <list>
+                <value>1205</value> </list>
+        </property>
+        <property name="deadlockLoserCodes">
+            <list>
+                <value>1213</value> </list>
+        </property>
+    </bean>
+
+    <bean id="PostgreSQL" class="org.springframework.jdbc.support.SQLErrorCodes">
+        <property name="badSqlGrammarCodes">
+            <list>
+                <value>42601</value> <value>42703</value> </list>
+        </property>
+         <property name="invalidDataAccessCodes">
+            <list>
+                <value>23502</value> </list>
+        </property>
+        <property name="duplicateKeyCodes">
+            <list>
+                <value>23505</value> </list>
+        </property>
+        <property name="dataIntegrityViolationCodes">
+            <list>
+                <value>23503</value> </list>
+        </property>
+        <property name="dataAccessResourceFailureCodes">
+            <list>
+                <value>08006</value> </list>
+        </property>
+        <property name="cannotAcquireLockCodes">
+          <list>
+            <value>55P03</value></list>
+        </property>
+        <property name="deadlockLoserCodes">
+          <list>
+            <value>40P01</value></list>
+        </property>
+
+    </bean>
+
+    <bean id="H2" class="org.springframework.jdbc.support.SQLErrorCodes">
+        <property name="badSqlGrammarCodes">
+            <list>
+                <value>42101</value>
+            </list>
+        </property>
+        <property name="duplicateKeyCodes">
+            <list>
+                <value>23505</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="DB2" class="org.springframework.jdbc.support.SQLErrorCodes">
+        <property name="duplicateKeyCodes">
+            <list>
+                <value>-803</value>
+            </list>
+        </property>
+    </bean>
+</beans>

--- a/default/generated/spring-framework/tests/spring-framework-5.x-to-6.0-data-access.test.yaml
+++ b/default/generated/spring-framework/tests/spring-framework-5.x-to-6.0-data-access.test.yaml
@@ -10,6 +10,20 @@ tests:
       mode: "source-only"
     hasIncidents:
       exactly: 1
+- ruleID: spring-framework-5.x-to-6.0-data-access-00002
+  testCases:
+  - name: tc-1
+    analysisParams:
+      mode: "source-only"
+    hasIncidents:
+      exactly: 5
+- ruleID: spring-framework-5.x-to-6.0-data-access-00003
+  testCases:
+  - name: tc-1
+    analysisParams:
+      mode: "source-only"
+    hasIncidents:
+      exactly: 4
 - ruleID: spring-framework-5.x-to-6.0-data-access-00010
   testCases:
     - name: tc-1

--- a/default/generated/spring-framework/tests/spring-framework-5.x-to-6.0-data-access.test.yaml
+++ b/default/generated/spring-framework/tests/spring-framework-5.x-to-6.0-data-access.test.yaml
@@ -24,3 +24,10 @@ tests:
         mode: "source-only"
       hasIncidents:
         exactly: 1
+- ruleID: spring-framework-5.x-to-6.0-data-access-00030
+  testCases:
+    - name: tc-1
+      analysisParams:
+        mode: "source-only"
+      hasIncidents:
+        exactly: 1


### PR DESCRIPTION
Resolution for #148
Followed the migration guide section titled **Data Access** and used the following:
```
For full backwards compatibility with database-specific error codes, consider re-enabling the legacy SQLErrorCodeSQLExceptionTranslator. This translator kicks in for user-provided sql-error-codes.xml files. It can simply pick up Spring's legacy default error code mappings as well when triggered by an empty user-provided file in the root of the classpath.
```