### PR TITLE
:bug: fix javaee-pom-to-quarkus-00050 rule

### DIFF
--- a/default/generated/quarkus/216-javaee-pom-to-quarkus.windup.yaml
+++ b/default/generated/quarkus/216-javaee-pom-to-quarkus.windup.yaml
@@ -156,8 +156,13 @@
       namespaces:
         m: http://maven.apache.org/POM/4.0.0
       xpath: |-
-        /m:project[not(m:build/m:plugins/m:plugin/m:artifactId/text() = 'maven-failsafe-plugin') or
-                        m:build/m:plugins/m:plugin/m:artifactId[text() = 'maven-failsafe-plugin' and not(../m:executions/m:execution/m:configuration/m:systemPropertyVariables/m:native.image.path)]]
+        /m:project[
+            not(m:build/m:plugins/m:plugin/m:artifactId/text() = 'maven-failsafe-plugin') or
+            m:build/m:plugins/m:plugin[m:artifactId[text() = 'maven-failsafe-plugin'] and 
+                not(m:executions/m:execution/m:configuration/m:systemPropertyVariables/m:native.image.path) and
+                not(m:configuration/m:systemPropertyVariables/m:native.image.path)
+            ]
+        ]
 - category: mandatory
   customVariables: []
   description: Add Maven profile to run the Quarkus native build


### PR DESCRIPTION
In this rule, the `native.image.path` property [may appear](https://maven.apache.org/surefire/maven-surefire-plugin/examples/system-properties.html) directly under `configuration` inside the plugin instead of inside the `execution` tag.