### PR TITLE
Update eap7 weblogic NonCatalogLogger constructor

### DIFF
--- a/.github/workflows/global-ci.yaml
+++ b/.github/workflows/global-ci.yaml
@@ -62,7 +62,7 @@ jobs:
         podman save -o /tmp/tackle2-hub.tar quay.io/konveyor/tackle2-hub:latest
 
     - name: Upload image as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: tackle2-hub
         path: /tmp/tackle2-hub.tar

--- a/default/generated/eap7/137-weblogic.windup.yaml
+++ b/default/generated/eap7/137-weblogic.windup.yaml
@@ -263,13 +263,9 @@
      ```
   ruleID: weblogic-eap7-11000
   when:
-    or:
-    - java.referenced:
-        location: METHOD_CALL
-        pattern: weblogic.i18n.logging.NonCatalogLogger(*)
-    - java.referenced:
-        location: CONSTRUCTOR_CALL
-        pattern: weblogic.i18n.logging.NonCatalogLogger*
+    java.referenced:
+      location: CONSTRUCTOR_CALL
+      pattern: NonCatalogLogger
 - category: mandatory
   customVariables: []
   description: WebLogic Oracle FCF JDBC property


### PR DESCRIPTION
Updating contructor selector to be more generic and match expected incidents. Note, this quite generic selector is not ideal, but works better than previous version that didn't matched well.

Related to: https://issues.redhat.com/browse/MTA-3845