### PR TITLE
Update eap7 weblogic NonCatalogLogger more generic

### DIFF
--- a/default/generated/eap7/137-weblogic.windup.yaml
+++ b/default/generated/eap7/137-weblogic.windup.yaml
@@ -264,7 +264,6 @@
   ruleID: weblogic-eap7-11000
   when:
     java.referenced:
-      location: CONSTRUCTOR_CALL
       pattern: NonCatalogLogger
 - category: mandatory
   customVariables: []


### PR DESCRIPTION
Updating NonCatalogLogger reference to be even more generic (to cover PromoService.java sample file).

Related to: https://github.com/konveyor/rulesets/pull/241
Fixes: https://issues.redhat.com/browse/MTA-3845