### PR TITLE
Add JBoss EAP XP6 rule eapxp_microprofile_bom_renamed-00001

### DIFF
--- a/default/generated/eapxp6/eapxp_microprofile_bom_renamed.mta.yaml
+++ b/default/generated/eapxp6/eapxp_microprofile_bom_renamed.mta.yaml
@@ -1,0 +1,12 @@
+- ruleID: eapxp_microprofile_bom_renamed-00001
+  description: "The JBoss EAP XP MicroProfile BOM has been renamed as Expansion BOM, and its Maven coordinates have changed."
+  category: mandatory
+  effort: 1
+  #links:
+  #  - url: https://docs.redhat.com/en/documentation/red_hat_jboss_enterprise_application_platform/8.1/html/jboss_eap_xp_6.0_upgrade_and_migration_guide/application_migration_default
+  #    title: "JBoss EAP XP 5.0 upgrade and migration guide: Chapter 3. Application Migration"
+  message: The JBoss EAP MicroProfile BOM has been renamed to JBoss EAP Expansion, and its Maven Coordinates have been changed, from `org.jboss.bom:jboss-eap-xp-microprofile` to `org.jboss.bom:jboss-eap-expansion`
+  when:
+    builtin.filecontent:
+      filePattern: pom\.xml
+      pattern: artifactId>jboss-eap-xp-microprofile<

--- a/default/generated/eapxp6/test/data/eapxp_microprofile_bom_renamed/pom.xml
+++ b/default/generated/eapxp6/test/data/eapxp_microprofile_bom_renamed/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>groupId</groupId>
+    <artifactId>artifactId</artifactId>
+    <version>1.0.0</version>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.bom</groupId>
+                <artifactId>jboss-eap-xp-microprofile</artifactId>
+                <version>5.0.0.GA</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/default/generated/eapxp6/test/eapxp_microprofile_bom_renamed.test.yaml
+++ b/default/generated/eapxp6/test/eapxp_microprofile_bom_renamed.test.yaml
@@ -1,0 +1,12 @@
+rulesPath: ../eapxp_microprofile_bom_renamed.mta.yaml
+providers:
+  - name: java
+    dataPath: ./data/eapxp_microprofile_bom_renamed
+  - name: builtin
+    dataPath: ./data/eapxp_microprofile_bom_renamed
+tests:
+  - ruleID: eapxp_microprofile_bom_renamed-00001
+    testCases:
+      - name: eapxp_microprofile_bom_renamed-1
+        hasIncidents:
+          exactly: 1


### PR DESCRIPTION
Fixes #258

Please note that the linked resource does not exists, but its value is extrapolated from XP5 doc ( https://docs.redhat.com/en/documentation/red_hat_jboss_enterprise_application_platform/8.0/html/jboss_eap_xp_5.0_upgrade_and_migration_guide/application_migration_default )
 