### PR TITLE
Fix weblogic import catchall

### DIFF
--- a/default/generated/eap7/129-weblogic-catchall.windup.yaml
+++ b/default/generated/eap7/129-weblogic-catchall.windup.yaml
@@ -29,10 +29,10 @@
         pattern: com.bea*
     - java.referenced:
         location: IMPORT
-        pattern: bea*
+        pattern: bea.jolt*
     - java.referenced:
         location: IMPORT
-        pattern: weblogic*
+        pattern: weblogic.(apache|application|cluster|coherence|common|connector|deploy|descriptor|diagnostics|ejb|health|i18n|i18ntools|jdbc|jms|jndi|jws|logging|management|messaging|net|protocol|rmi|security|server|servlet|socket|time|transaction|utils|websocket|workarea|wsee|wtc|xml)*
 - category: optional
   customVariables:
   - name: remainder


### PR DESCRIPTION
The language server seems unable to search for imports if only the top-level is given. Imports found from API docs: https://docs.oracle.com/middleware/1213/wls/WLAPI/toc.htm 