### PR TITLE
fix(patternfly): Update import patterns to support multi-line imports

### DIFF
--- a/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-charts.yaml
+++ b/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-charts.yaml
@@ -8,7 +8,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*from.*@patternfly/react-charts$
+      pattern: import[\s\S]*from[\s\S]*['"]@patternfly/react-charts['"]
       filePattern: \.(j|t)sx?$
   message: |-
     Victory-based charts have moved to a "victory" directory in @patternfly/react-charts

--- a/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-chip.yaml
+++ b/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-chip.yaml
@@ -7,7 +7,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*Chip.*from.*@patternfly/react-core$
+      pattern: import[\s\S]*Chip[\s\S]*from[\s\S]*['"]@patternfly/react-core['"]
       filePattern: \.(j|t)sx?$
   message: |-
     Chip has been deprecated. Running the fix flag will update your imports to our deprecated package, but we suggest using Label instead.
@@ -40,7 +40,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*ChipGroup.*from.*@patternfly/react-core$
+      pattern: import[\s\S]*ChipGroup[\s\S]*from[\s\S]*['"]@patternfly/react-core['"]
       filePattern: \.(j|t)sx?$
   message: |-
     ChipGroup has been deprecated. Running the fix flag will update your imports to our deprecated package, but we suggest using LabelGroup instead.

--- a/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-component-groups.yaml
+++ b/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-component-groups.yaml
@@ -45,7 +45,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*ContentHeader.*from.*@patternfly/react-component-groups$
+      pattern: import[\s\S]*ContentHeader[\s\S]*from[\s\S]*['"]@patternfly/react-component-groups['"]
       filePattern: \.(j|t)sx?$
   message: |-
     In react-component-groups, we've renamed ContentHeader component to PageHeader

--- a/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-component-renames.yaml
+++ b/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-component-renames.yaml
@@ -8,7 +8,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*ContentHeader.*from.*@patternfly/react-component-groups$
+      pattern: import[\s\S]*ContentHeader[\s\S]*from[\s\S]*['"]@patternfly/react-component-groups['"]
       filePattern: \.(j|t)sx?$
   message: |-
     In react-component-groups, ContentHeader component has been renamed to
@@ -73,7 +73,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*MastheadBrand.*from.*@patternfly/react-core$
+      pattern: import[\s\S]*MastheadBrand[\s\S]*from[\s\S]*['"]@patternfly/react-core['"]
       filePattern: \.(j|t)sx?$
   message: |-
     Our old implementation of MastheadBrand has been renamed to MastheadLogo,

--- a/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-components.yaml
+++ b/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-components.yaml
@@ -176,7 +176,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*Text.*from '@patternfly/react-core'$
+      pattern: import[\s\S]*Text[\s\S]*from[\s\S]*['"]@patternfly/react-core['"]
       filePattern: \.(j|t)sx?$
   message: |-
     Text component has been renamed to Content component in PatternFly 6

--- a/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-deprecated-components.yaml
+++ b/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-deprecated-components.yaml
@@ -8,7 +8,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*Chip.*from.*@patternfly/react-core$
+      pattern: import[\s\S]*Chip[\s\S]*from[\s\S]*['"]@patternfly/react-core['"]
       filePattern: \.(j|t)sx?$
   message: |-
     Chip has been deprecated. Use Label instead.
@@ -42,7 +42,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*DragDrop.*from.*@patternfly/react-core$
+      pattern: import[\s\S]*DragDrop[\s\S]*from[\s\S]*['"]@patternfly/react-core['"]
       filePattern: \.(j|t)sx?$
   message: |-
     DragDrop has been deprecated. For PatternFly 6 compatibility, update imports to '@patternfly/react-core/deprecated'.
@@ -78,7 +78,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*Droppable.*from.*@patternfly/react-core$
+      pattern: import[\s\S]*Droppable[\s\S]*from[\s\S]*['"]@patternfly/react-core['"]
       filePattern: \.(j|t)sx?$
   message: |-
     DragDrop components have been deprecated. For PatternFly 6 compatibility, update imports to '@patternfly/react-core/deprecated'.
@@ -114,7 +114,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*Draggable.*from.*@patternfly/react-core$
+      pattern: import[\s\S]*Draggable[\s\S]*from[\s\S]*['"]@patternfly/react-core['"]
       filePattern: \.(j|t)sx?$
   message: |-
     DragDrop components have been deprecated. For PatternFly 6 compatibility, update imports to '@patternfly/react-core/deprecated'.
@@ -150,7 +150,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*DualListSelector.*from.*@patternfly/react-core$
+      pattern: import[\s\S]*DualListSelector[\s\S]*from[\s\S]*['"]@patternfly/react-core['"]
       filePattern: \.(j|t)sx?$
   message: |-
     The previous implementation of DualListSelector has been deprecated. Use

--- a/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-drag-drop.yaml
+++ b/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-drag-drop.yaml
@@ -7,7 +7,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*DragDrop.*from.*@patternfly/react-core$
+      pattern: import[\s\S]*DragDrop[\s\S]*from[\s\S]*['"]@patternfly/react-core['"]
       filePattern: \.(j|t)sx?$
   message: |-
     DragDrop has been deprecated. Running the fix flag will update your imports
@@ -52,7 +52,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*Draggable.*from.*@patternfly/react-core$
+      pattern: import[\s\S]*Draggable[\s\S]*from[\s\S]*['"]@patternfly/react-core['"]
       filePattern: \.(j|t)sx?$
   message: |-
     DragDrop has been deprecated. Running the fix flag will update your imports
@@ -88,7 +88,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*Droppable.*from.*@patternfly/react-core$
+      pattern: import[\s\S]*Droppable[\s\S]*from[\s\S]*['"]@patternfly/react-core['"]
       filePattern: \.(j|t)sx?$
   message: |-
     DragDrop has been deprecated. Running the fix flag will update your imports

--- a/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-dual-list-selector.yaml
+++ b/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-dual-list-selector.yaml
@@ -8,7 +8,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*DualListSelector.*from.*@patternfly/react-core$
+      pattern: import[\s\S]*DualListSelector[\s\S]*from[\s\S]*['"]@patternfly/react-core['"]
       filePattern: \.(j|t)sx?$
   message: |-
     Our previous implementation of DualListSelector has been deprecated. Codemods
@@ -54,7 +54,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*DualListSelector.*from.*@patternfly/react-core/next$
+      pattern: import[\s\S]*DualListSelector[\s\S]*from[\s\S]*['"]@patternfly/react-core/next['"]
       filePattern: \.(j|t)sx?$
   message: |-
     Our Next implementation of DualListSelector has been promoted as our recommended

--- a/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-import-path.yaml
+++ b/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-import-path.yaml
@@ -8,7 +8,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*Modal.*from.*@patternfly/react-core$
+      pattern: import[\s\S]*Modal[\s\S]*from[\s\S]*['"]@patternfly/react-core['"]
       filePattern: \.(j|t)sx?$
   message: |-
     The previous implementation of Modal has been deprecated and moved to
@@ -43,7 +43,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*Modal.*from.*@patternfly/react-core/next$
+      pattern: import[\s\S]*Modal[\s\S]*from[\s\S]*['"]@patternfly/react-core/next['"]
       filePattern: \.(j|t)sx?$
   message: |-
     The Next implementation of Modal has been promoted as the recommended
@@ -78,7 +78,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*Tile.*from.*@patternfly/react-core$
+      pattern: import[\s\S]*Tile[\s\S]*from[\s\S]*['"]@patternfly/react-core['"]
       filePattern: \.(j|t)sx?$
   message: |-
     Tile has been deprecated. Use Card instead.
@@ -112,7 +112,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*from.*@patternfly/react-tokens/dist/esm/color_$
+      pattern: import[\s\S]*from[\s\S]*['"]@patternfly/react-tokens/dist/esm/color_['"]
       filePattern: \.(j|t)sx?$
   message: |-
     React tokens, whose value is a Patternfly token variable (with prefix

--- a/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-import-paths.yaml
+++ b/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-import-paths.yaml
@@ -7,7 +7,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*from.*@patternfly/react-core/v5$
+      pattern: import[\s\S]*from[\s\S]*['"]@patternfly/react-core/v5['"]
       filePattern: \.(j|t)sx?$
   message: |-
     Import paths need to be updated from v5 to v6

--- a/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-imports.yaml
+++ b/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-imports.yaml
@@ -8,7 +8,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*from '@patternfly/react-core'$
+      pattern: import[\s\S]*from[\s\S]*['"]@patternfly/react-core['"]
       filePattern: \.(j|t)sx?$
   message: |-
     PatternFly 6 requires more specific imports from component subdirectories

--- a/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-interface-renames.yaml
+++ b/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-interface-renames.yaml
@@ -8,7 +8,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*FormFiledGroupHeaderTitleTextObject.*from.*@patternfly/react-core$
+      pattern: import[\s\S]*FormFiledGroupHeaderTitleTextObject[\s\S]*from[\s\S]*['"]@patternfly/react-core['"]
       filePattern: \.(j|t)sx?$
   message: |-
     There was a typo in FormFiledGroupHeaderTitleTextObject interface. It

--- a/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-patternfly-v6.yaml
+++ b/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-patternfly-v6.yaml
@@ -8,7 +8,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*from.*@patternfly/react-core/dist/js/components$
+      pattern: import[\s\S]*from[\s\S]*['"]@patternfly/react-core/dist/js/components['"]
       filePattern: \.(j|t)sx?$
   message: |-
     Imports from @patternfly/react-core/dist/js/components should now be imported
@@ -53,7 +53,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*from.*@patternfly/react-core/dist/esm/components$
+      pattern: import[\s\S]*from[\s\S]*['"]@patternfly/react-core/dist/esm/components['"]
       filePattern: \.(j|t)sx?$
   message: |-
     Imports from @patternfly/react-core/dist/esm/components should now be

--- a/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-promoted-components.yaml
+++ b/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-promoted-components.yaml
@@ -8,7 +8,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*DualListSelector.*from.*@patternfly/react-core/next$
+      pattern: import[\s\S]*DualListSelector[\s\S]*from[\s\S]*['"]@patternfly/react-core/next['"]
       filePattern: \.(j|t)sx?$
   message: |-
     The Next implementation of DualListSelector has been promoted as the recommended

--- a/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-removed-components.yaml
+++ b/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-removed-components.yaml
@@ -8,7 +8,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*KebabToggle.*from.*@patternfly/react-core/deprecated$
+      pattern: import[\s\S]*KebabToggle[\s\S]*from[\s\S]*['"]@patternfly/react-core/deprecated['"]
       filePattern: \.(j|t)sx?$
   message: |-
     KebabToggle has been removed from PatternFly. Use MenuToggle component

--- a/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-toolbar.yaml
+++ b/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-toolbar.yaml
@@ -161,7 +161,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*ToolbarChipGroupContent.*from.*@patternfly/react-core$
+      pattern: import[\s\S]*ToolbarChipGroupContent[\s\S]*from[\s\S]*['"]@patternfly/react-core['"]
       filePattern: \.(j|t)sx?$
   message: |-
     The ToolbarChipGroupContent component has been renamed to ToolbarLabelGroupContent

--- a/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-unauthorized-access.yaml
+++ b/preview/nodejs/patternfly/patternfly-v5-to-patternfly-v6-unauthorized-access.yaml
@@ -45,7 +45,7 @@
   - konveyor.io/target=patternfly-v6
   when:
     builtin.filecontent:
-      pattern: import.*NotAuthorized.*from.*@patternfly/react-component-groups$
+      pattern: import[\s\S]*NotAuthorized[\s\S]*from[\s\S]*['"]@patternfly/react-component-groups['"]
       filePattern: \.(j|t)sx?$
   message: |-
     In react-component-groups, the NotAuthorized component has been renamed


### PR DESCRIPTION
## Summary
Fixes #315 - PatternFly migration rules now correctly detect multi-line import statements.

## Problem
The current regex patterns used in PatternFly v5 to v6 migration rules only match single-line imports. Multi-line imports like the following were not detected:

```typescript
import { 
  DragDrop
} from "@patternfly/react-core";
```

## Solution
Updated all import detection patterns to use `[\s\S]*` instead of `.*`, which matches any character including newlines.

**Pattern changes:**
- Before: `import.*Component.*from.*@patternfly/package$`
- After: `import[\s\S]*Component[\s\S]*from[\s\S]*['"]@patternfly/package['"]`

## Changes
- Updated **30 import patterns** across **17 rule files**
- `[\s\S]*` matches any character including newlines (instead of `.*`)
- Added quote matching around package names for better accuracy
- Removed `$` anchor since patterns now span multiple lines

## Files Modified
- patternfly-v5-to-patternfly-v6-charts.yaml
- patternfly-v5-to-patternfly-v6-chip.yaml
- patternfly-v5-to-patternfly-v6-component-groups.yaml
- patternfly-v5-to-patternfly-v6-component-renames.yaml
- patternfly-v5-to-patternfly-v6-components.yaml
- patternfly-v5-to-patternfly-v6-deprecated-components.yaml
- patternfly-v5-to-patternfly-v6-drag-drop.yaml
- patternfly-v5-to-patternfly-v6-dual-list-selector.yaml
- patternfly-v5-to-patternfly-v6-import-path.yaml
- patternfly-v5-to-patternfly-v6-import-paths.yaml
- patternfly-v5-to-patternfly-v6-imports.yaml
- patternfly-v5-to-patternfly-v6-interface-renames.yaml
- patternfly-v5-to-patternfly-v6-patternfly-v6.yaml
- patternfly-v5-to-patternfly-v6-promoted-components.yaml
- patternfly-v5-to-patternfly-v6-removed-components.yaml
- patternfly-v5-to-patternfly-v6-toolbar.yaml
- patternfly-v5-to-patternfly-v6-unauthorized-access.yaml

## Test Plan
- [ ] Verify rules now detect single-line imports: `import { DragDrop } from "@patternfly/react-core";`
- [ ] Verify rules now detect multi-line imports:
  ```typescript
  import { 
    DragDrop
  } from "@patternfly/react-core";
  ```
- [ ] Confirm no regression in existing rule detection

## References
- Issue: #315
- Related PR: #314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of PatternFly library imports with flexible whitespace and quote formatting across multiple lines, enhancing pattern matching reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->