### PR TITLE
Fix Angular v16-to-v21 migration rule issues

### DIFF
--- a/preview/nodejs/angular/angular-v16-to-v21/migration-rules.yaml/angular-16-to-angular-21-api-removal.yaml
+++ b/preview/nodejs/angular/angular-v16-to-v21/migration-rules.yaml/angular-16-to-angular-21-api-removal.yaml
@@ -8,26 +8,31 @@
   when:
     nodejs.referenced:
       pattern: ComponentFactoryResolver
-  message: 'ComponentFactoryResolver has been removed from Router APIs.
+  message: 'ComponentFactoryResolver has been removed from Angular APIs.
 
 
-    Replace `ComponentFactoryResolver` with `removed`.
+    The factory pattern is no longer needed. Use ViewContainerRef.createComponent() directly with the component class.
 
 
     Before:
 
-    ```
+    ```typescript
 
-    router.createComponent(ComponentFactoryResolver);
+    constructor(private resolver: ComponentFactoryResolver, private vcr: ViewContainerRef) {
+      const factory = this.resolver.resolveComponentFactory(MyComponent);
+      this.vcr.createComponent(factory);
+    }
 
     ```
 
 
     After:
 
-    ```
+    ```typescript
 
-    router.createComponent();
+    constructor(private vcr: ViewContainerRef) {
+      this.vcr.createComponent(MyComponent);
+    }
 
     ```'
   customVariables: []

--- a/preview/nodejs/angular/angular-v16-to-v21/migration-rules.yaml/angular-16-to-angular-21-import-path-change.yaml
+++ b/preview/nodejs/angular/angular-v16-to-v21/migration-rules.yaml/angular-16-to-angular-21-import-path-change.yaml
@@ -13,8 +13,8 @@
     of other packages.
 
 
-    Replace `import { {{ component }} }; from ApplicationConfig` with `import { {{
-    component }} } from @angular/core`.
+    Replace `import { {{ component }} } from ''some_old_package''` with `import { {{
+    component }} } from ''@angular/core''`.
 
 
     Before:
@@ -53,8 +53,8 @@
   message: 'XhrFactory should now be imported from @angular/common instead of @angular/common/http.
 
 
-    Replace `import { {{ component }} }; from XhrFactory from @angular/common/http`
-    with `import { {{ component }} } from XhrFactory from @angular/common`.
+    Replace `import { {{ component }} } from ''@angular/common/http''` with `import
+    { {{ component }} } from ''@angular/common''`.
 
 
     Before:

--- a/preview/nodejs/angular/angular-v16-to-v21/migration-rules.yaml/angular-16-to-angular-21-router-event-type-change.yaml
+++ b/preview/nodejs/angular/angular-v16-to-v21/migration-rules.yaml/angular-16-to-angular-21-router-event-type-change.yaml
@@ -7,7 +7,7 @@
   - konveyor.io/target=angular-21
   when:
     nodejs.referenced:
-      pattern: Event
+      pattern: RouterEvent
   message: 'RouterEvent is no longer part of the Event union type, requiring explicit
     inclusion.
 


### PR DESCRIPTION
## Summary
Addresses feedback from the Angular rulesets PR review:

- Fix ComponentFactoryResolver migration example to show actual usage pattern with ViewContainerRef instead of incorrect router.createComponent example
- Fix import syntax errors in ApplicationConfig and XhrFactory migration messages (removed stray semicolons and duplicate "from" keywords)
- Fix pattern mismatch in RouterEvent type change rule (was matching Event instead of RouterEvent)

## Changes
1. **angular-16-to-angular-21-api-removal.yaml**: Updated ComponentFactoryResolver example to show the real migration from `ComponentFactoryResolver.resolveComponentFactory()` pattern to direct `ViewContainerRef.createComponent()` usage
2. **angular-16-to-angular-21-import-path-change.yaml**: Fixed malformed import statements in both ApplicationConfig and XhrFactory rules
3. **angular-16-to-angular-21-router-event-type-change.yaml**: Changed pattern from `Event` to `RouterEvent` to correctly match RouterEvent usages

## Test plan
- Reviewed YAML syntax is valid
- Verified examples show correct Angular migration patterns
- Confirmed patterns match rule descriptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Angular 16 to 21 migration guidance for ComponentFactoryResolver, recommending ViewContainerRef.createComponent() directly
  * Enhanced migration rules for module removal and import path updates
  * Refined migration rule targeting for more accurate detection

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->