### PR TITLE
:sparkles: Trigger seed on push

### DIFF
--- a/.github/workflows/trigger-seed.yaml
+++ b/.github/workflows/trigger-seed.yaml
@@ -12,10 +12,13 @@ jobs:
     steps:
       - name: Get Token
         id: get_workflow_token
-        uses: peter-murray/workflow-application-token-action@v3
+        uses: peter-murray/workflow-application-token-action@v4
         with:
           application_id: ${{ vars.KONVEYOR_BOT_ID }}
           application_private_key: ${{ secrets.KONVEYOR_BOT_KEY }}
+          # Permission needed to send repository_dispatch (trigger workflow in target repo)
+          permissions: "actions:write"
+          revoke_token: true
       - name: Dispatch event to create seed PR
         uses: peter-evans/repository-dispatch@v4
         with:


### PR DESCRIPTION
The idea is to automatically create a seed in the tackle2-seed repo whenever a push is made to `main` or one of the release branches.

Companion PR: https://github.com/konveyor/tackle2-seed/pull/98
Fixes: https://github.com/konveyor/tackle2-seed/issues/95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow that triggers seed processes on pushes to main and release-* branches, dispatching an event to the seed service.

* **Note**
  * Internal infrastructure change with no user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->