### PR TITLE
adding quotes around the pattern string to make transmission work

### DIFF
--- a/stable/java/spring-framework/spring-framework-5.x-to-6.0-security.yaml
+++ b/stable/java/spring-framework/spring-framework-5.x-to-6.0-security.yaml
@@ -743,7 +743,7 @@
   when:
     builtin.filecontent:
       filePattern: .*\.java
-      pattern: \".*hasIpAddress\(.*\"
+      pattern: '".*hasIpAddress\(.*"'
   description: Migrate hasIpAddress to access(AuthorizationManager)
   message: |
     `hasIpAddress` has no DSL equivalent in `authorizeHttpRequests`. As such, you need to change any calls to `hasIpAddress` to using an `AuthorizationManager`.


### PR DESCRIPTION
The issue is that during transmission of the rule (either parsing of yaml into strings or during the engine -> builtin provider), the "``` character is dropped. 

Quoting the entire pattern string should make the entire pattern stable.