### PR TITLE
:bug: Remove test case of non existing rule

### DIFF
--- a/stable/nodejs/patternfly/tests/patternfly-v5-to-patternfly-v6-components.test.yaml
+++ b/stable/nodejs/patternfly/tests/patternfly-v5-to-patternfly-v6-components.test.yaml
@@ -15,11 +15,6 @@ tests:
   - name: tc-1
     hasIncidents:
       atLeast: 1
-- ruleID: patternfly-v5-to-patternfly-v6-components-00020
-  testCases:
-  - name: tc-1
-    hasIncidents:
-      atLeast: 1
 - ruleID: patternfly-v5-to-patternfly-v6-components-00030
   testCases:
   - name: tc-1


### PR DESCRIPTION
Fixes:
```
$ kantra test patternfly-v5-to-patternfly-v6-components.test.yaml
ERRO[0000] failed during execution                       error="failed writing rules - rule patternfly-v5-to-patternfly-v6-components-00020 not found in file ../patternfly-v5-to-patternfly-v6-components.yaml"
patternfly-v5-to-patternfly-v6-components.test.yaml                                                                                                   0/1 PASSED
  Unexpected error:                                                                                                                                   0/1 PASSED
    - failed writing rules - rule patternfly-v5-to-patternfly-v6-components-00020 not found in file ../patternfly-v5-to-patternfly-v6-components.yaml 
------------------------------------------------------------
  Rules Summary:      0/1 (0.00%) FAILED
  Test Cases Summary: 0/1 (0.00%) FAILED
------------------------------------------------------------
ERRO[0000] failed running tests                          error="failed to execute one or more tests"
Error: failed to execute one or more tests
```