### PR TITLE
Update Windows File System Path rule to support forward-slash (#364)

### DIFF
--- a/stable/java/os/209-os-specific.windup.yaml
+++ b/stable/java/os/209-os-specific.windup.yaml
@@ -13,7 +13,7 @@
   when:
     builtin.filecontent:
       filePattern: .*\.(java|properties|jsp|jspf|tag|xml|txt)
-      pattern: '[A-z]:([\\][^\n\t]+)+|(\\\\([^\\\,\n\t]+)\\\S+)+'
+      pattern: '(?<![A-Za-z])[A-Za-z]:([\\/][^\n\t]+)+|(\\\\/([^\\/\,\n\t]+)\\/\S+)+'
 - category: mandatory
   customVariables: []
   description: Dynamic-Link Library (DLL)


### PR DESCRIPTION
Fixes #364

Modified the pattern in the regex of `stable/java/os/209-os-specific.windup.yaml ` to successfully capture the intermixing for forward-slash and backslash characters in windows filepaths I was seeing in the field:

pattern: '(?<![A-z])[A-z]{1}:([\\/][^\n\t]+)+|(\\\\/([^\\/\,\n\t]+)\\/\S+)+'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined Windows path detection in code analysis rules to improve accuracy and reduce false positives when identifying file paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->