### PR TITLE
:sparkles: Quarkus rules improvements

### DIFF
--- a/.github/workflows/local-ci.yaml
+++ b/.github/workflows/local-ci.yaml
@@ -208,6 +208,7 @@ jobs:
           cd ~/.config/.kantra
           ID=$(podman create --name kantra-download quay.io/konveyor/kantra:latest)
           podman cp ${ID}:/usr/local/bin/kantra .
+          podman cp ${ID}:/usr/local/bin/java-external-provider .
           podman cp ${ID}:/usr/local/etc/maven.default.index .
           podman cp ${ID}:/usr/bin/fernflower.jar .
           podman cp ${ID}:/jdtls .

--- a/.github/workflows/local-ci.yaml
+++ b/.github/workflows/local-ci.yaml
@@ -219,7 +219,7 @@ jobs:
           if [ "${{ steps.find-tests.outputs.run_all_tests }}" == "true" ]; then
             # Run all tests (for nightly runs or manual workflow_dispatch)
             echo "Running all tests"
-            JVM_MAX_MEM=3072m RUN_LOCAL=1 ./kantra test ./rulesets --log-level 50 | tee output.log || true
+            JVM_MAX_MEM=3072m ./kantra test ./rulesets --log-level 50 --run-local=true | tee output.log || true
           elif [ "${{ steps.find-tests.outputs.has_tests }}" == "true" ]; then
             # Run tests for changed rules only
             # Test file paths are under stable/ or preview/; after move they are under ./rulesets/stable/ or ./rulesets/preview/
@@ -241,7 +241,7 @@ jobs:
               fi
             done
             if [ -n "$adjusted_test_files" ]; then
-              JVM_MAX_MEM=3072m RUN_LOCAL=1 ./kantra test $adjusted_test_files --log-level 50 | tee output.log || true
+              JVM_MAX_MEM=3072m ./kantra test $adjusted_test_files --log-level 50 --run-local=true | tee output.log || true
             else
               echo "Rules Summary: 0/0" > message.md
               echo "Test Cases Summary: 0/0" >> message.md

--- a/docs/open-issues-quarkus-ruleset-assessment.md
+++ b/docs/open-issues-quarkus-ruleset-assessment.md
@@ -1,0 +1,273 @@
+# Assessment: open `quarkus-ruleset` GitHub issues
+
+This document summarizes [open issues labeled `quarkus-ruleset`](https://github.com/konveyor/rulesets/issues?q=state%3Aopen%20label%3Aquarkus-ruleset) on `konveyor/rulesets`, restates each request, and outlines what implementing it would likely involve in this repository.
+
+**Repository note:** Issues often link to `default/generated/quarkus/*.windup.yaml`. In this tree, the maintained Spring-to-Quarkus rules live under [`stable/java/quarkus/`](../stable/java/quarkus/) (about 35 rule files). Any implementation work should target those paths unless the project’s packaging pipeline explicitly copies from elsewhere.
+
+**Effort scale:** Each issue is assigned a rank **1–5** (1 = smallest effort, 5 = largest). **Medium** splits the difference between focused YAML work and multi-rule or open-ended research. **Medium–large** means substantial content or many triggers/tests, without a full ruleset restructure.
+
+---
+
+## Summary (sorted by effort, then issue number)
+
+| Effort | Issue | Title (short) | Nature |
+|:------:|-------|---------------|--------|
+| **1** | [#289](https://github.com/konveyor/rulesets/issues/289) | Fix JMX rule messaging (native vs JMX; Micrometer) | Copy + links in existing rules |
+| **3** | [#290](https://github.com/konveyor/rulesets/issues/290) | Improve Spring DI rule (category, table, CDI guidance) | YAML + possible new `when` clauses + tests |
+| **3** | [#292](https://github.com/konveyor/rulesets/issues/292) | Explain `@SpringBootApplication` composition in Quarkus terms | Message + optional extra rules |
+| **3** | [#294](https://github.com/konveyor/rulesets/issues/294) | Spring Cloud Consul → Quarkus Stork | New rule file + tests + dependency patterns |
+| **3** | [#295](https://github.com/konveyor/rulesets/issues/295) | Container image build guidance (Jib, Buildpack, S2I, …) | New rule file(s) + tests |
+| **4** | [#291](https://github.com/konveyor/rulesets/issues/291) | Expand actuator → Quarkus observability mapping | Research + one or many rules/messages |
+| **4** | [#298](https://github.com/konveyor/rulesets/issues/298) | Devservices as local alternative for SQL/NoSQL/messaging | Many technology-specific dependency rules or one broad guide |
+| **5** | [#288](https://github.com/konveyor/rulesets/issues/288) | Split rules: “pure Quarkus” vs “Quarkus Spring” | Product/structure + many rules |
+| **5** | [#293](https://github.com/konveyor/rulesets/issues/293) | Sharpen generic catchall + dependency conversion table | Many specific rules or doc-heavy catchall; tests blocked |
+
+---
+
+## [#289](https://github.com/konveyor/rulesets/issues/289) — Review and improve `228-springboot-jmx-to-quarkus`
+
+**Effort: 1 — Small**
+
+### Original issue (summary)
+
+- The rule **conflates JMX with GraalVM Native Image**; native image is not specific to Spring→Quarkus.
+- If the goal is Spring→Quarkus **and** JMX/operational concerns, the guidance should align with **Micrometer / telemetry** on Quarkus, with links such as:
+  - [Quarkus Micrometer guide](https://quarkus.io/guides/telemetry-micrometer)
+  - [Quarkiverse Micrometer registry docs](https://docs.quarkiverse.io/quarkus-micrometer-registry)
+
+### Current code (this repo)
+
+[`stable/java/quarkus/228-springboot-jmx-to-quarkus.windup.yaml`](../stable/java/quarkus/228-springboot-jmx-to-quarkus.windup.yaml): two `mandatory` rules (XML `MBeanExporter`, annotations under `org.springframework.jmx.*`) with messages that emphasize **native image** rather than **JMX portability / observability alternatives**.
+
+### What it would take to implement
+
+1. **Rewrite `description`, `message`, and `effort`** so incidents explain:
+   - JMX limitations on Quarkus (especially native) **as a JMX concern**, not “Spring migration = native.”
+   - Practical alternatives: Micrometer metrics, health, optional JVM-mode notes if relevant.
+2. **Add `links`** to the guides above (and optionally SmallRye Health if health is part of the story).
+3. **Optional split:** separate “native” nuance from “JVM mode” in the message if you want precision without extra rules.
+4. **Tests:** update [`tests/228-springboot-jmx-to-quarkus.windup.test.yaml`](../stable/java/quarkus/tests/228-springboot-jmx-to-quarkus.windup.test.yaml) expected messages/links.
+
+Mostly editorial and link curation.
+
+---
+
+## [#290](https://github.com/konveyor/rulesets/issues/290) — Improve `225-springboot-di-to-quarkus`
+
+**Effort: 3 — Medium**
+
+### Original issue (summary)
+
+- Change category from **`potential` to `mandatory`** for rule `springboot-di-to-quarkus-00000` (Spring Beans / `spring-di` extension).
+- Add a rule (or rules) reflecting the **conversion table** from [Quarkus Spring DI – conversion table](https://quarkus.io/guides/spring-di#conversion-table).
+- For unsupported types like `BeanPostProcessor`: don’t stop at “not supported”; point users to **CDI Extension** / `@Interceptor` / `@Decorator` patterns (with the table’s Spring vs CDI mapping).
+- Similarly for **programmatic `ApplicationContext`** usage: document **`CDI.current()`** as the preferred approach (issue includes example snippets).
+
+### Current code (this repo)
+
+[`stable/java/quarkus/225-springboot-di-to-quarkus.windup.yaml`](../stable/java/quarkus/225-springboot-di-to-quarkus.windup.yaml):
+
+- `springboot-di-to-quarkus-00000` is **`potential`**, triggers on `org.springframework.spring-beans`.
+- `springboot-di-to-quarkus-00002` already flags `BeanPostProcessor` (and related) **implements** types with a short “will not be executed” message; **`ApplicationContext` is only mentioned in the message text**, not as a dedicated `when` condition.
+
+### What it would take to implement
+
+1. **One-line policy change:** set `category: mandatory` on `00000` (aligns with other “replace dependency” rules in this folder).
+2. **Message and link upgrades for `00002`:** expand with CDI extension / interceptor / decorator guidance; add links to Spring DI guide sections.
+3. **New conditions for `ApplicationContext`:** e.g. `java.referenced` on `org.springframework.context.ApplicationContext` (injection, implements, extends—need to avoid extreme noise; may scope to `IMPLEMENTS_TYPE` / `INHERITANCE` / method return types per analyzer capabilities).
+4. **Conversion table:** either embed a **condensed** table in a single rule message or add **targeted** rules per high-value Spring stereotype (more work, clearer incidents).
+5. **Tests:** extend [`tests/225-springboot-di-to-quarkus.windup.test.yaml`](../stable/java/quarkus/tests/225-springboot-di-to-quarkus.windup.test.yaml) and fixtures under `tests/data/225-springboot-di-to-quarkus/`.
+
+Main cost is tuning `when` clauses to limit false positives and updating tests.
+
+---
+
+## [#292](https://github.com/konveyor/rulesets/issues/292) — Improve `220-springboot-annotations-to-quarkus`
+
+**Effort: 3 — Medium**
+
+### Original issue (summary)
+
+- `@SpringBootApplication` composes three concerns (per [Spring Boot docs](https://docs.spring.io/spring-boot/reference/using/using-the-springbootapplication-annotation.html)):
+  - `@EnableAutoConfiguration`
+  - `@ComponentScan`
+  - `@SpringBootConfiguration` (vs plain `@Configuration` for Boot-centric testing/config detection)
+- The rule should explain how to achieve these in **Quarkus** (and/or Quarkus Spring), not only “remove annotation or optional Spring dependency.”
+
+### Current code (this repo)
+
+[`stable/java/quarkus/220-springboot-annotations-to-quarkus.windup.yaml`](../stable/java/quarkus/220-springboot-annotations-to-quarkus.windup.yaml): single rule on `@SpringBootApplication` with the “remove or optional `spring-boot-autoconfigure`” message.
+
+### What it would take to implement
+
+1. **Rewrite the main message** into sections: auto-configuration → Quarkus extensions/build-time model; component scan → Quarkus bean discovery / Jandex / [`@ApplicationScoped`](https://quarkus.io/guides/cdi-reference) patterns; `@SpringBootConfiguration` / `@Configuration` → CDI `@ApplicationScoped` + Quarkus testing guidance.
+2. **Optional additional rules** with `java.referenced` on `EnableAutoConfiguration`, `ComponentScan`, `SpringBootConfiguration` for users who use them **without** `@SpringBootApplication`.
+3. **Links:** Quarkus CDI, Quarkus Spring (if documenting compatibility path), testing guide.
+4. **Tests:** update [`tests/220-springboot-annotations-to-quarkus.windup.test.yaml`](../stable/java/quarkus/tests/220-springboot-annotations-to-quarkus.windup.test.yaml).
+
+Mostly documentation quality; extra rules add test surface.
+
+---
+
+## [#294](https://github.com/konveyor/rulesets/issues/294) — Spring Cloud Consul → Quarkus Stork
+
+**Effort: 3 — Medium**
+
+### Original issue (summary)
+
+- Add a **new rule** for migrating from **Spring Cloud Consul** to **Quarkus Stork**, referencing [Stork guide](https://quarkus.io/guides/stork).
+
+### What it would take to implement
+
+1. **Identify coordinates:** e.g. `org.springframework.cloud:spring-cloud-starter-consul-*`, `spring-cloud-consul-discovery`, etc. (align with versions used in Spring Cloud BOMs).
+2. **New rule file** under `stable/java/quarkus/` (e.g. `238-springboot-cloud-consul-to-quarkus-stork.windup.yaml` or similar; follow next free numeric convention per CONTRIBUTING).
+3. **Message content:** Stork + Consul client configuration at high level; link to Stork; note that this is **architectural** (service discovery/load balancing), not a drop-in API swap.
+4. **Tests:** sample `pom.xml` under `tests/data/...` and `.test.yaml` asserting incidents.
+5. **Overlap:** ensure no conflict with generic Spring Cloud rules if any exist.
+
+Pattern matches existing files like [`222-springboot-cloud-config-client-to-quarkus.windup.yaml`](../stable/java/quarkus/222-springboot-cloud-config-client-to-quarkus.windup.yaml).
+
+---
+
+## [#295](https://github.com/konveyor/rulesets/issues/295) — Container image build guidance (Quarkus)
+
+**Effort: 3 — Medium**
+
+### Original issue (summary)
+
+- Add rules explaining how to **build container images** with Quarkus per [container-image guide](https://quarkus.io/guides/container-image).
+- Quarkus supports **multiple** approaches (Buildpack, OpenShift S2I, Jib, Docker, etc.); **several rules** may be appropriate (to be evaluated).
+
+### What it would take to implement
+
+1. **Trigger strategy:** These are often **not** Spring-specific; rules might key off:
+   - `quarkus-container-image-*` extensions already in POM, or
+   - presence of `docker-maven-plugin` / `jib-maven-plugin` / OpenShift plugin, or
+   - generic “Spring Boot app migrating to Quarkus” + Dockerfile present.
+2. **One file or several:** e.g. separate rules per build strategy with `links` to the right subsection of the guide.
+3. **Tests:** minimal POMs and optional `Dockerfile` snippets in `tests/data/`.
+4. **Product fit:** decide whether this belongs in **Spring→Quarkus** ruleset only or a **general Quarkus** ruleset (if one exists or gets added).
+
+Scope depends on number of strategies and triggers.
+
+---
+
+## [#291](https://github.com/konveyor/rulesets/issues/291) — Improve `219-springboot-actuator-to-quarkus`
+
+**Effort: 4 — Medium–large**
+
+### Original issue (summary)
+
+- Replacing Actuator with **SmallRye Health** alone is **insufficient**; Actuator exposes many endpoints (beans, caches, health, info, conditions, configprops, env, loggers, heapdump, threaddump, metrics, scheduledtasks, mappings, …).
+- Desired: **map** what Actuator exposes to what Quarkus offers (health, metrics, config, logging, etc.).
+
+### Current code (this repo)
+
+[`stable/java/quarkus/219-springboot-actuator-to-quarkus.windup.yaml`](../stable/java/quarkus/219-springboot-actuator-to-quarkus.windup.yaml): dependency-based rules for actuator artifacts + a **properties** rule mapping `management.endpoints.web.exposure.include` health exposure to `quarkus.smallrye-health.root-path`.
+
+### What it would take to implement
+
+1. **Research matrix:** For each Actuator endpoint category, document Quarkus equivalents (e.g. SmallRye Health, Micrometer/Prometheus, logging config, `quarkus.arc` dev mode, etc.) and **honest gaps** (e.g. heap dump may be “use JDK tools / platform”, not a single extension).
+2. **Implementation options:**
+   - **A)** One rich `message` on the main actuator dependency rule with a structured table (fastest, one incident).
+   - **B)** Multiple rules: `java.dependency` + optional `builtin.filecontent` for `management.endpoint.*.enabled` to suggest specific extensions (more precise, more YAML and tests).
+3. **Links:** SmallRye Health, Micrometer, possibly management/observability guides.
+4. **Tests:** new or updated fixtures with `application.properties`/`application.yml` and expected incidents.
+
+Depends on A vs B; the research and keeping the matrix accurate across Quarkus versions is ongoing maintenance.
+
+---
+
+## [#298](https://github.com/konveyor/rulesets/issues/298) — Devservices for local SQL, NoSQL, messaging, etc.
+
+**Effort: 4 — Medium–large**
+
+### Original issue (summary)
+
+- Propose **Quarkus Dev Services** (and related dependencies) as an alternative to running local infrastructure via containers manually—covering **SQL, NoSQL, messaging**, etc.
+
+### What it would take to implement
+
+1. **Breadth:** Either:
+   - **Many small rules:** `java.dependency` on `spring-boot-starter-data-jpa` + JDBC driver → suggest `quarkus-jdbc-*` + dev services; same idea for Kafka (`spring-kafka` → `quarkus-messaging-kafka`), Mongo, Redis, etc., or
+   - **A few umbrella rules** with long messages listing categories and linking to [Dev Services overview](https://quarkus.io/guides/dev-services) (less precise).
+2. **Accuracy:** Dev Services require **specific** Quarkus extensions; messages must avoid promising dev services for stacks Quarkus doesn’t auto-start for that extension.
+3. **Overlap:** Spring→Quarkus rules already exist for JPA, cache, etc.; add **devservices** as an extra paragraph or **child rule** to avoid contradiction.
+4. **Tests:** per dependency fixture or consolidated sample apps.
+
+If done comprehensively, larger than a single new rule file; smaller if limited to top 5–10 Spring starters.
+
+---
+
+## [#288](https://github.com/konveyor/rulesets/issues/288) — Split the rules into two migration paths (Quarkus vs Quarkus Spring)
+
+**Effort: 5 — Large**
+
+### Original issue (summary)
+
+- Today a user may migrate Spring (Boot) either to **idiomatic Quarkus** or to **Quarkus with the Spring compatibility layer** (“Quarkus Spring”).
+- Proposed: two **families** of rules:
+  - Spring(Boot) → **Quarkus Spring**
+  - Spring(Boot) → **Quarkus** (native idioms)
+- **Common** rules (e.g. POM parent/BOM detection) would live in a **`shared`** or **`common`** folder.
+
+### What it would take to implement
+
+1. **Design agreement (outside YAML-only work)**  
+   - How Konveyor users **select** one path vs the other (separate ruleset bundles, labels, tags, or analyzer configuration).  
+   - Whether **both** paths can run together without duplicate/conflicting incidents.
+
+2. **Repository layout**  
+   - New directories under `stable/java/` (e.g. `quarkus-spring/` vs `quarkus/`) or subfolders under `quarkus/` with clear naming.  
+   - CONTRIBUTING-style updates so contributors know where to add rules.
+
+3. **Rule audit and duplication**  
+   - Roughly **35** Spring→Quarkus rule files today; many are already “use Quarkus extension X” vs “rewrite to Y.” Each would need classification into **path A**, **path B**, or **shared**.  
+   - **Shared** rules: dependency-only checks (e.g. parent POM) are easier; rules that assume **removal** of Spring APIs vs **optional Spring** dependency need splitting or conditional messaging (if the engine supports it cleanly).
+
+4. **Labels and metadata**  
+   - Consistent `labels` / tags so UIs and CI can filter by migration strategy.
+
+5. **Tests**  
+   - Every moved or duplicated rule needs `tests/` and `tests/data/` aligned with the new layout; CI runs `kantra test` per changed files.
+
+**Risk:** Highest scope and process cost; easy to end up with duplicated maintenance unless the split is strictly mechanical (copy + tweak messages).
+
+---
+
+## [#293](https://github.com/konveyor/rulesets/issues/293) — `226-springboot-generic-catchall`: precision + conversion table
+
+**Effort: 5 — Large**
+
+### Original issue (summary)
+
+- Many rules already cover specific Spring features; the **catchall** scans POMs for `{group}:{artifact}` but is **generic**—hard for users to act on.
+- Ask: make the rule **more precise** and add a **conversion table** mapping Spring dependencies to recommended Quarkus extensions/features.
+
+### Current code (this repo)
+
+[`stable/java/quarkus/226-springboot-generic-catchall.windup.yaml`](../stable/java/quarkus/226-springboot-generic-catchall.windup.yaml): single `potential` rule with `java.dependency` `name: '{group}.{artifact}'` and templated `{{group}}:{{artifact}}` in the message.
+
+[`tests/226-springboot-generic-catchall.windup.test.yaml`](../stable/java/quarkus/tests/226-springboot-generic-catchall.windup.test.yaml): **fully commented** with `# FIXME: requires ability to match dependencies using regex`.
+
+### What it would take to implement
+
+1. **Precision strategies:**
+   - **Replace catchall** with a **long list** of explicit `java.dependency` rules for known Spring artifacts not covered elsewhere (high maintenance, best UX).
+   - Or **narrow** the catchall with **exclusions** (if the analyzer supports negation / lists)—depends on [analyzer-lsp rule capabilities](https://github.com/konveyor/analyzer-lsp/blob/main/docs/rules.md).
+2. **Conversion table:** large curated map (Spring Boot starters → Quarkus extensions); overlaps with existing rules—need deduplication to avoid **double incidents**.
+3. **Testing:** today’s tests are blocked; implementing reliable tests may require **upstream rule engine** features or abandoning the generic dependency template.
+
+Core difficulty is **scalable maintenance** and **testability** of a generic dependency matcher.
+
+---
+
+## Cross-cutting recommendations
+
+1. **Path alignment:** Update issue links or comments to point at `stable/java/quarkus/` when contributing here, so implementers don’t edit only generated output.
+2. **Ordering:** Sections above follow **ascending effort** (rank 1 → 5), then issue number within the same rank. Quick wins cluster at **#289**; **#288** and **#293** need design before large edits.
+3. **Blocked tests:** **#293** is tied to generic dependency matching; confirm analyzer support before investing in a huge dependency matrix.
+
+---
+
+*Generated as a planning aid; effort ranks are estimates and assume familiarity with Konveyor rule YAML and `kantra test`.*

--- a/stable/java/quarkus/219-springboot-actuator-to-quarkus.windup.yaml
+++ b/stable/java/quarkus/219-springboot-actuator-to-quarkus.windup.yaml
@@ -1,7 +1,6 @@
 - category: mandatory
   customVariables: []
-  description: Replace the Spring Boot Actuator dependency with Quarkus Smallrye Health
-    extension
+  description: Replace Spring Boot Actuator with Quarkus health, metrics, info and management interface capabilities
   effort: 5
   labels:
   - konveyor.io/source=springboot
@@ -9,8 +8,29 @@
   links:
   - title: Quarkus - Smallrye Health
     url: https://quarkus.io/guides/smallrye-health
-  message: "Replace the Spring Boot Actuator dependency with Quarkus Smallrye Health
-    extension. \n It has to be replaced by `io.quarkus:quarkus-smallrye-health` artifact."
+  - title: Quarkus - Micrometer and monitoring
+    url: https://quarkus.io/guides/telemetry-micrometer
+  - title: Quarkus - Management interface reference
+    url: https://quarkus.io/guides/management-interface-reference
+  - title: Spring Boot Actuator endpoints reference
+    url: https://docs.spring.io/spring-boot/reference/actuator/endpoints.html
+  message: |-
+    Spring Boot Actuator dependency detected. Replace Actuator usage with Quarkus operational extensions and management endpoints.
+
+    Recommended Quarkus baseline:
+    - Health: `io.quarkus:quarkus-smallrye-health`
+    - Metrics / Prometheus: `io.quarkus:quarkus-micrometer` (+ registry extension as needed)
+    - Info endpoint: `io.quarkus:quarkus-info`
+    - Dedicated management server/path (optional): `quarkus.management.*` and `/q` endpoints
+
+    Actuator endpoint mapping guidance:
+    - `health` -> `/q/health` (or management interface endpoint)
+    - `metrics` / `prometheus` -> Micrometer endpoint(s)
+    - `info` -> `/q/info` via `quarkus-info`
+    - `loggers`, `env`, `configprops`, `beans`, `conditions`, `mappings`, `scheduledtasks` -> reassess per use case; there is no single 1:1 Quarkus Actuator replacement for all of these
+    - `heapdump` / `threaddump` -> use JVM/container diagnostics and platform tooling rather than Actuator-specific endpoints
+
+    A migration usually requires both dependency changes and endpoint/configuration redesign.
   ruleID: springboot-actuator-to-quarkus-0100
   when:
     or:
@@ -42,3 +62,31 @@
     builtin.filecontent:
       filePattern: application.*\.(properties|yml|yaml)
       pattern: management.endpoints.web.exposure.include.*health
+- category: mandatory
+  customVariables: []
+  description: Review non-health Actuator endpoint exposure and map to Quarkus operational endpoints
+  effort: 3
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=quarkus
+  links:
+  - title: Quarkus - Micrometer and monitoring
+    url: https://quarkus.io/guides/telemetry-micrometer
+  - title: Quarkus - Management interface reference
+    url: https://quarkus.io/guides/management-interface-reference
+  - title: Spring Boot Actuator endpoints reference
+    url: https://docs.spring.io/spring-boot/reference/actuator/endpoints.html
+  message: |-
+    Spring Actuator non-health web endpoint exposure detected.
+
+    For endpoints like `metrics`, `prometheus`, `info`, `env`, `loggers`, `mappings`, `scheduledtasks`, or `threaddump`, map each need explicitly to Quarkus capabilities:
+    - metrics/prometheus -> Micrometer (+ registry)
+    - info -> `quarkus-info`
+    - operational endpoint isolation -> `quarkus.management.*`
+
+    Some Actuator endpoints have no direct 1:1 equivalent in Quarkus and require operational/process changes.
+  ruleID: springboot-actuator-to-quarkus-0210
+  when:
+    builtin.filecontent:
+      filePattern: application.*\.(properties|yml|yaml)
+      pattern: management.endpoints.web.exposure.include.*(metrics|prometheus|info|env|loggers|mappings|scheduledtasks|threaddump|heapdump|beans|conditions|configprops|caches)

--- a/stable/java/quarkus/220-springboot-annotations-to-quarkus.windup.yaml
+++ b/stable/java/quarkus/220-springboot-annotations-to-quarkus.windup.yaml
@@ -1,22 +1,87 @@
 - category: mandatory
   customVariables: []
-  description: Remove the SpringBoot @SpringBootApplication annotation
+  description: Replace SpringBootApplication bootstrap model with Quarkus bootstrap and CDI
   effort: 1
   labels:
   - konveyor.io/source=springboot
   - konveyor.io/target=quarkus
-  links: []
-  message: "Remove the SpringBoot @SpringBootApplication annotation.\n\n A Spring
-    Boot application contains a \"main\" class with the @SpringBootApplication annotation.
-    A Quarkus application does not have such a class. Two different alternatives can
-    be followed - either\n to remove the \"main\" class associated with the annotation,
-    or add the `org.springframework.boot:spring-boot-autoconfigure` dependency as
-    an `optional` Maven dependency. An optional dependency \n is available when an
-    application compiles but is not packaged with the application at runtime. Doing
-    this would allow the application to compile without modification, but you\n would
-    also need to maintain a Spring version along with the Quarkus application."
+  links:
+  - title: Quarkus CDI reference
+    url: https://quarkus.io/guides/cdi-reference
+  - title: Quarkus Spring DI guide
+    url: https://quarkus.io/guides/spring-di
+  - title: Quarkus testing guide
+    url: https://quarkus.io/guides/getting-started-testing
+  message: |-
+    Remove or refactor the SpringBoot `@SpringBootApplication` bootstrap model for Quarkus.
+
+    `@SpringBootApplication` combines three concerns; in Quarkus they map differently:
+    - `@EnableAutoConfiguration`: Quarkus configures features by adding Quarkus extensions at build time (no Spring Boot auto-configuration runtime model).
+    - `@ComponentScan`: Quarkus uses CDI bean discovery with bean-defining annotations (for example `@ApplicationScoped`, `@Singleton`), not Spring component scanning semantics.
+    - `@SpringBootConfiguration`: use CDI scopes and producer methods (`@Produces`) for bean registration; for tests, use Quarkus testing patterns instead of Spring Boot configuration detection.
+
+    If needed as an intermediate step, keeping `org.springframework.boot:spring-boot-autoconfigure` as `optional` may allow compilation, but this keeps Spring compatibility baggage and should not be the target end state.
   ruleID: springboot-annotations-to-quarkus-00000
   when:
     java.referenced:
       location: ANNOTATION
       pattern: org.springframework.boot.autoconfigure.SpringBootApplication
+- category: mandatory
+  customVariables: []
+  description: Replace Spring EnableAutoConfiguration with Quarkus extension-driven configuration
+  effort: 1
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=quarkus
+  links:
+  - title: Quarkus extensions catalog
+    url: https://quarkus.io/extensions/
+  message: |-
+    Spring `@EnableAutoConfiguration` detected.
+
+    Quarkus does not use Spring Boot runtime auto-configuration. Select and configure the required Quarkus extensions explicitly (for example web, data, security, observability) and move related settings to `application.properties`.
+  ruleID: springboot-annotations-to-quarkus-00001
+  when:
+    java.referenced:
+      location: ANNOTATION
+      pattern: org.springframework.boot.autoconfigure.EnableAutoConfiguration
+- category: mandatory
+  customVariables: []
+  description: Replace Spring ComponentScan with CDI bean discovery conventions
+  effort: 1
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=quarkus
+  links:
+  - title: Quarkus CDI reference
+    url: https://quarkus.io/guides/cdi-reference
+  message: |-
+    Spring `@ComponentScan` detected.
+
+    Quarkus relies on CDI bean discovery and bean-defining annotations (for example `@ApplicationScoped`, `@Singleton`, `@Dependent`) instead of Spring component scanning behavior. Review package and bean scope assumptions accordingly.
+  ruleID: springboot-annotations-to-quarkus-00002
+  when:
+    java.referenced:
+      location: ANNOTATION
+      pattern: org.springframework.context.annotation.ComponentScan
+- category: mandatory
+  customVariables: []
+  description: Replace SpringBootConfiguration with CDI configuration and Quarkus testing patterns
+  effort: 1
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=quarkus
+  links:
+  - title: Quarkus CDI reference
+    url: https://quarkus.io/guides/cdi-reference
+  - title: Quarkus testing guide
+    url: https://quarkus.io/guides/getting-started-testing
+  message: |-
+    Spring `@SpringBootConfiguration` detected.
+
+    In Quarkus, register beans using CDI scopes and producer methods instead of relying on Spring Boot configuration class detection. Update integration tests to Quarkus testing conventions.
+  ruleID: springboot-annotations-to-quarkus-00003
+  when:
+    java.referenced:
+      location: ANNOTATION
+      pattern: org.springframework.boot.SpringBootConfiguration

--- a/stable/java/quarkus/225-springboot-di-to-quarkus.windup.yaml
+++ b/stable/java/quarkus/225-springboot-di-to-quarkus.windup.yaml
@@ -1,4 +1,4 @@
-- category: potential
+- category: mandatory
   customVariables: []
   description: Replace the SpringBoot Dependency Injection artifact with Quarkus 'spring-di'
     extension
@@ -54,8 +54,14 @@
   links:
   - title: Quarkus DI Guide - important technical note
     url: https://quarkus.io/guides/spring-di#important-technical-note
-  message: Spring infrastructure classes (like `org.springframework.beans.factory.config.BeanPostProcessor`
-    , `org.springframework.context.ApplicationContext` for example) will not be executed.
+  - title: Quarkus CDI reference
+    url: https://quarkus.io/guides/cdi-reference
+  message: |-
+    Spring infrastructure extension points like `BeanFactoryPostProcessor` and `BeanPostProcessor` are not executed by Quarkus Spring DI.
+
+    Use CDI-native alternatives depending on the use case:
+    - Generic container lifecycle customization: CDI extensions (for example observing `ProcessInjectionTarget`)
+    - Cross-cutting behavior on selected beans: CDI interceptors (`@Interceptor`) or decorators (`@Decorator`)
   ruleID: springboot-di-to-quarkus-00002
   when:
     or:
@@ -74,3 +80,75 @@
     - java.referenced:
         location: IMPLEMENTS_TYPE
         pattern: org.springframework.beans.factory.config.SmartInstantiationAwareBeanPostProcessor
+- category: mandatory
+  customVariables: []
+  description: Apply Quarkus Spring DI conversion guidance for common Spring DI annotations
+  effort: 3
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=quarkus
+  links:
+  - title: Quarkus Spring DI conversion table
+    url: https://quarkus.io/guides/spring-di#conversion-table
+  - title: Quarkus CDI reference
+    url: https://quarkus.io/guides/cdi-reference
+  message: |-
+    Spring DI annotation usage detected. Verify each annotation against Quarkus Spring DI compatibility and CDI equivalents.
+
+    Common conversions:
+    - `@Autowired` -> `@Inject`
+    - `@Component` / `@Service` / `@Repository` -> CDI bean-defining annotations (for example `@ApplicationScoped`, `@Singleton`)
+    - `@Qualifier` -> CDI `@Qualifier`
+    - `@Value` -> `@ConfigProperty` (MicroProfile Config)
+    - `@Bean` / `@Configuration` -> CDI producer methods (`@Produces`) and CDI bean scopes
+  ruleID: springboot-di-to-quarkus-00003
+  when:
+    or:
+    - java.referenced:
+        location: ANNOTATION
+        pattern: org.springframework.beans.factory.annotation.Autowired
+    - java.referenced:
+        location: ANNOTATION
+        pattern: org.springframework.beans.factory.annotation.Qualifier
+    - java.referenced:
+        location: ANNOTATION
+        pattern: org.springframework.beans.factory.annotation.Value
+    - java.referenced:
+        location: ANNOTATION
+        pattern: org.springframework.stereotype.Component
+    - java.referenced:
+        location: ANNOTATION
+        pattern: org.springframework.stereotype.Service
+    - java.referenced:
+        location: ANNOTATION
+        pattern: org.springframework.stereotype.Repository
+    - java.referenced:
+        location: ANNOTATION
+        pattern: org.springframework.context.annotation.Bean
+    - java.referenced:
+        location: ANNOTATION
+        pattern: org.springframework.context.annotation.Configuration
+- category: mandatory
+  customVariables: []
+  description: Replace Spring ApplicationContext bean lookup with CDI programmatic lookup
+  effort: 3
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=quarkus
+  links:
+  - title: Quarkus CDI reference - programmatic lookup
+    url: https://quarkus.io/guides/cdi-reference
+  message: |-
+    Spring `ApplicationContext` usage detected.
+
+    Quarkus Spring DI does not execute the Spring `ApplicationContext` runtime model. Replace programmatic bean lookup patterns like `applicationContext.getBean(...)` with CDI programmatic lookup, for example:
+    `CDI.current().select(MyService.class).get()`
+  ruleID: springboot-di-to-quarkus-00004
+  when:
+    or:
+    - java.referenced:
+        location: IMPORT
+        pattern: org.springframework.context.ApplicationContext
+    - java.referenced:
+        location: METHOD_CALL
+        pattern: org.springframework.context.ApplicationContext.getBean*

--- a/stable/java/quarkus/228-springboot-jmx-to-quarkus.windup.yaml
+++ b/stable/java/quarkus/228-springboot-jmx-to-quarkus.windup.yaml
@@ -1,16 +1,21 @@
 - category: mandatory
   customVariables: []
-  description: Spring JMX is not supported by Quarkus with GraalVM on a Native Image
+  description: Spring JMX export is not a supported Quarkus migration path; use Micrometer-based observability instead
   effort: 13
   labels:
   - konveyor.io/source=springboot
   - konveyor.io/target=quarkus
-  links: []
+  links:
+  - title: Quarkus - Micrometer metrics
+    url: https://quarkus.io/guides/telemetry-micrometer
+  - title: Quarkiverse - Micrometer registry reference
+    url: https://docs.quarkiverse.io/quarkus-micrometer-registry
   message: |-
     Spring JMX XML configuration detected:
 
-     Spring JMX is not supported by Quarkus with the GraalVM Native compilation.
-     Spring JMX can be used with the Quarkus Hotspot compilation however.
+     Spring JMX configuration (for example `org.springframework.jmx.export.MBeanExporter` in XML) does not translate to a supported operational model on Quarkus. Quarkus does not document carrying Spring JMX forward as part of a Spring Boot to Quarkus migration.
+
+     JMX is especially limited for Quarkus native image builds. Even on JVM mode, you should plan to replace JMX-centric management and Actuator-style introspection with Quarkus-native observability—metrics and health—typically using Micrometer (see links below).
   ruleID: springboot-jmx-to-quarkus-00000
   when:
     builtin.xml:
@@ -19,17 +24,22 @@
       xpath: //*/c:bean/@class[matches(self::node(), 'org.springframework.jmx.export.MBeanExporter')]
 - category: mandatory
   customVariables: []
-  description: Spring JMX is not supported by Quarkus with GraalVM on a Native Image
+  description: Spring JMX annotations are not a supported Quarkus migration path; use Micrometer-based observability instead
   effort: 13
   labels:
   - konveyor.io/source=springboot
   - konveyor.io/target=quarkus
-  links: []
+  links:
+  - title: Quarkus - Micrometer metrics
+    url: https://quarkus.io/guides/telemetry-micrometer
+  - title: Quarkiverse - Micrometer registry reference
+    url: https://docs.quarkiverse.io/quarkus-micrometer-registry
   message: |-
     Spring JMX annotation configuration detected:
 
-     Spring JMX is not supported by Quarkus with the GraalVM Native compilation.
-     Spring JMX can be used with the Quarkus Hotspot compilation however.
+     Spring JMX annotations (under `org.springframework.jmx`, for example `@ManagedResource`) do not have a direct Quarkus equivalent. Migrating from Spring Boot to Quarkus should treat JMX MBeans as legacy operational surface and redesign around Quarkus extensions.
+
+     Native image further restricts practical JMX usage; prefer Micrometer metrics, SmallRye Health, and related guides (see links below) rather than retaining Spring JMX.
   ruleID: springboot-jmx-to-quarkus-00001
   when:
     java.referenced:

--- a/stable/java/quarkus/241-springboot-cloud-consul-to-quarkus-stork.windup.yaml
+++ b/stable/java/quarkus/241-springboot-cloud-consul-to-quarkus-stork.windup.yaml
@@ -1,0 +1,55 @@
+- category: mandatory
+  customVariables: []
+  description: Replace Spring Cloud Consul Discovery with Quarkus Stork Consul service discovery
+  effort: 3
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=quarkus
+  links:
+  - title: Quarkus - Getting Started with SmallRye Stork
+    url: https://quarkus.io/guides/stork
+  - title: Quarkus - Stork reference guide
+    url: https://quarkus.io/guides/stork-reference
+  message: |-
+    Replace Spring Cloud Consul Discovery dependency with Quarkus Stork-based service discovery.
+
+    Spring Cloud Consul Discovery artifacts:
+    - `org.springframework.cloud:spring-cloud-starter-consul-discovery`
+    - `org.springframework.cloud:spring-cloud-consul-discovery`
+
+    Quarkus migration guidance:
+    - Add `io.quarkus:quarkus-smallrye-stork`
+    - Add `io.smallrye.stork:stork-service-discovery-consul`
+    - Configure service discovery and load balancing with `quarkus.stork.<service-name>.*` properties
+  ruleID: springboot-cloud-consul-to-quarkus-stork-00000
+  when:
+    or:
+    - java.dependency:
+        lowerbound: 0.0.0
+        name: org.springframework.cloud.spring-cloud-starter-consul-discovery
+    - java.dependency:
+        lowerbound: 0.0.0
+        name: org.springframework.cloud.spring-cloud-consul-discovery
+- category: mandatory
+  customVariables: []
+  description: Migrate Spring Cloud Consul configuration properties to Quarkus Stork configuration
+  effort: 2
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=quarkus
+  links:
+  - title: Quarkus - Getting Started with SmallRye Stork
+    url: https://quarkus.io/guides/stork
+  message: |-
+    Spring Cloud Consul discovery configuration detected.
+
+    Replace `spring.cloud.consul.discovery.*` configuration with Quarkus Stork properties, for example:
+    - `quarkus.stork.<service-name>.service-discovery.type=consul`
+    - `quarkus.stork.<service-name>.service-discovery.consul-host=<host>`
+    - `quarkus.stork.<service-name>.service-discovery.consul-port=<port>`
+    - `quarkus.stork.<service-name>.load-balancer.type=round-robin`
+  ruleID: springboot-cloud-consul-to-quarkus-stork-00001
+  when:
+    builtin.filecontent:
+      filePattern: application.*\.(properties|yml|yaml)
+      pattern: spring.cloud.consul.discovery\..*

--- a/stable/java/quarkus/242-springboot-devservices-to-quarkus.windup.yaml
+++ b/stable/java/quarkus/242-springboot-devservices-to-quarkus.windup.yaml
@@ -1,0 +1,47 @@
+- category: potential
+  customVariables: []
+  description: Use Quarkus Dev Services as a local development alternative for Spring infrastructure dependencies
+  effort: 2
+  labels:
+  - konveyor.io/source=springboot
+  - konveyor.io/target=quarkus
+  links:
+  - title: Quarkus Dev Services overview
+    url: https://quarkus.io/guides/dev-services
+  - title: Quarkus Dev Services for databases
+    url: https://quarkus.io/guides/databases-dev-services
+  - title: Quarkus Dev Services for Kafka
+    url: https://quarkus.io/guides/kafka-dev-services
+  message: |-
+    Spring dependency with local infrastructure expectations detected.
+
+    During migration to Quarkus, prefer Quarkus Dev Services in dev/test mode to run backing services automatically (when no explicit external connection is configured), instead of manually provisioning local containers.
+
+    Suggested mapping (examples):
+    - `spring-boot-starter-data-jpa` -> Quarkus datasource/JDBC extension + Dev Services for databases
+    - `spring-boot-starter-data-mongodb` -> Quarkus MongoDB extension + Dev Services
+    - `spring-boot-starter-data-redis` -> Quarkus Redis extension + Dev Services
+    - `spring-kafka` -> Quarkus Kafka extension + Dev Services for Kafka
+    - `spring-boot-starter-amqp` -> Quarkus AMQP / messaging extension + Dev Services
+
+    Notes:
+    - Dev Services are mainly for development and test workflows.
+    - Most Dev Services require a working container runtime (Docker/Podman).
+  ruleID: springboot-devservices-to-quarkus-00000
+  when:
+    or:
+    - java.dependency:
+        lowerbound: 0.0.0
+        name: org.springframework.boot.spring-boot-starter-data-jpa
+    - java.dependency:
+        lowerbound: 0.0.0
+        name: org.springframework.boot.spring-boot-starter-data-mongodb
+    - java.dependency:
+        lowerbound: 0.0.0
+        name: org.springframework.boot.spring-boot-starter-data-redis
+    - java.dependency:
+        lowerbound: 0.0.0
+        name: org.springframework.kafka.spring-kafka
+    - java.dependency:
+        lowerbound: 0.0.0
+        name: org.springframework.boot.spring-boot-starter-amqp

--- a/stable/java/quarkus/tests/219-springboot-actuator-to-quarkus.windup.test.yaml
+++ b/stable/java/quarkus/tests/219-springboot-actuator-to-quarkus.windup.test.yaml
@@ -10,11 +10,16 @@ tests:
   - name: tc-1
     hasIncidents:
       exactly: 3
-      messageMatches: Replace the Spring Boot Actuator dependency with Quarkus Smallrye
-        Health extension
+      messageMatches: Spring Boot Actuator dependency detected
 - ruleID: springboot-actuator-to-quarkus-0200
   testCases:
   - name: tc-1
     hasIncidents:
       exactly: 1
       messageMatches: Replace `management.endpoints.web.exposure.include=health`
+- ruleID: springboot-actuator-to-quarkus-0210
+  testCases:
+  - name: tc-1
+    hasIncidents:
+      exactly: 1
+      messageMatches: Spring Actuator non-health web endpoint exposure detected

--- a/stable/java/quarkus/tests/220-springboot-annotations-to-quarkus.windup.test.yaml
+++ b/stable/java/quarkus/tests/220-springboot-annotations-to-quarkus.windup.test.yaml
@@ -15,17 +15,17 @@ tests:
   testCases:
   - name: tc-1
     hasIncidents:
-      exactly: 1
+      exactly: 4
       messageMatches: Spring `@EnableAutoConfiguration` detected
 - ruleID: springboot-annotations-to-quarkus-00002
   testCases:
   - name: tc-1
     hasIncidents:
-      exactly: 1
+      exactly: 8
       messageMatches: Spring `@ComponentScan` detected
 - ruleID: springboot-annotations-to-quarkus-00003
   testCases:
   - name: tc-1
     hasIncidents:
-      exactly: 1
+      exactly: 3
       messageMatches: Spring `@SpringBootConfiguration` detected

--- a/stable/java/quarkus/tests/220-springboot-annotations-to-quarkus.windup.test.yaml
+++ b/stable/java/quarkus/tests/220-springboot-annotations-to-quarkus.windup.test.yaml
@@ -10,4 +10,22 @@ tests:
   - name: tc-1
     hasIncidents:
       exactly: 1
-      messageMatches: Remove the SpringBoot @SpringBootApplication annotation
+      messageMatches: Remove or refactor the SpringBoot `@SpringBootApplication` bootstrap model for Quarkus
+- ruleID: springboot-annotations-to-quarkus-00001
+  testCases:
+  - name: tc-1
+    hasIncidents:
+      exactly: 1
+      messageMatches: Spring `@EnableAutoConfiguration` detected
+- ruleID: springboot-annotations-to-quarkus-00002
+  testCases:
+  - name: tc-1
+    hasIncidents:
+      exactly: 1
+      messageMatches: Spring `@ComponentScan` detected
+- ruleID: springboot-annotations-to-quarkus-00003
+  testCases:
+  - name: tc-1
+    hasIncidents:
+      exactly: 1
+      messageMatches: Spring `@SpringBootConfiguration` detected

--- a/stable/java/quarkus/tests/225-springboot-di-to-quarkus.windup.test.yaml
+++ b/stable/java/quarkus/tests/225-springboot-di-to-quarkus.windup.test.yaml
@@ -23,7 +23,7 @@ tests:
   testCases:
   - name: tc-1
     hasIncidents:
-      exactly: 5
+      exactly: 12
       messageMatches: Spring infrastructure extension points like.*
 - ruleID: springboot-di-to-quarkus-00003
   testCases:

--- a/stable/java/quarkus/tests/225-springboot-di-to-quarkus.windup.test.yaml
+++ b/stable/java/quarkus/tests/225-springboot-di-to-quarkus.windup.test.yaml
@@ -24,4 +24,16 @@ tests:
   - name: tc-1
     hasIncidents:
       exactly: 5
-      messageMatches: Spring infrastructure classe.*
+      messageMatches: Spring infrastructure extension points like.*
+- ruleID: springboot-di-to-quarkus-00003
+  testCases:
+  - name: tc-1
+    hasIncidents:
+      exactly: 2
+      messageMatches: Spring DI annotation usage detected.*
+- ruleID: springboot-di-to-quarkus-00004
+  testCases:
+  - name: tc-1
+    hasIncidents:
+      exactly: 2
+      messageMatches: Spring `ApplicationContext` usage detected.*

--- a/stable/java/quarkus/tests/228-springboot-jmx-to-quarkus.windup.test.yaml
+++ b/stable/java/quarkus/tests/228-springboot-jmx-to-quarkus.windup.test.yaml
@@ -10,10 +10,10 @@ tests:
   - name: tc-1
     hasIncidents:
       exactly: 1
-      messageMatches: 'Spring JMX XML configuration detected:'
+      messageMatches: 'Spring JMX XML configuration detected:*'
 - ruleID: springboot-jmx-to-quarkus-00001
   testCases:
   - name: tc-1
     hasIncidents:
       exactly: 2
-      messageMatches: 'Spring JMX annotation configuration detected:'
+      messageMatches: 'Spring JMX annotation configuration detected:*'

--- a/stable/java/quarkus/tests/228-springboot-jmx-to-quarkus.windup.test.yaml
+++ b/stable/java/quarkus/tests/228-springboot-jmx-to-quarkus.windup.test.yaml
@@ -15,5 +15,5 @@ tests:
   testCases:
   - name: tc-1
     hasIncidents:
-      exactly: 2
+      exactly: 35
       messageMatches: 'Spring JMX annotation configuration detected:*'

--- a/stable/java/quarkus/tests/241-springboot-cloud-consul-to-quarkus-stork.windup.test.yaml
+++ b/stable/java/quarkus/tests/241-springboot-cloud-consul-to-quarkus-stork.windup.test.yaml
@@ -1,0 +1,20 @@
+rulesPath: ../241-springboot-cloud-consul-to-quarkus-stork.windup.yaml
+providers:
+- name: java
+  dataPath: ./data/241-springboot-cloud-consul-to-quarkus-stork
+- name: builtin
+  dataPath: ./data/241-springboot-cloud-consul-to-quarkus-stork
+tests:
+- ruleID: springboot-cloud-consul-to-quarkus-stork-00000
+  testCases:
+  - name: tc-1
+    hasIncidents:
+      exactly: 2
+      messageMatches: Replace Spring Cloud Consul Discovery dependency with Quarkus
+        Stork-based service discovery
+- ruleID: springboot-cloud-consul-to-quarkus-stork-00001
+  testCases:
+  - name: tc-1
+    hasIncidents:
+      exactly: 3
+      messageMatches: Spring Cloud Consul discovery configuration detected

--- a/stable/java/quarkus/tests/242-springboot-devservices-to-quarkus.windup.test.yaml
+++ b/stable/java/quarkus/tests/242-springboot-devservices-to-quarkus.windup.test.yaml
@@ -1,0 +1,13 @@
+rulesPath: ../242-springboot-devservices-to-quarkus.windup.yaml
+providers:
+- name: java
+  dataPath: ./data/242-springboot-devservices-to-quarkus
+- name: builtin
+  dataPath: ./data/242-springboot-devservices-to-quarkus
+tests:
+- ruleID: springboot-devservices-to-quarkus-00000
+  testCases:
+  - name: tc-1
+    hasIncidents:
+      exactly: 3
+      messageMatches: Spring dependency with local infrastructure expectations detected

--- a/stable/java/quarkus/tests/data/220-springboot-annotations-to-quarkus/src/main/java/com/example/apps/ExplicitSpringConfiguration.java
+++ b/stable/java/quarkus/tests/data/220-springboot-annotations-to-quarkus/src/main/java/com/example/apps/ExplicitSpringConfiguration.java
@@ -1,0 +1,11 @@
+package com.example.apps;
+
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootConfiguration
+@EnableAutoConfiguration
+@ComponentScan(basePackages = "com.example.apps")
+public class ExplicitSpringConfiguration {
+}

--- a/stable/java/quarkus/tests/data/225-springboot-di-to-quarkus/src/main/java/com/example/apps/ApplicationContextLookupUsage.java
+++ b/stable/java/quarkus/tests/data/225-springboot-di-to-quarkus/src/main/java/com/example/apps/ApplicationContextLookupUsage.java
@@ -1,0 +1,16 @@
+package com.example.apps;
+
+import org.springframework.context.ApplicationContext;
+
+public class ApplicationContextLookupUsage {
+
+    private final ApplicationContext applicationContext;
+
+    public ApplicationContextLookupUsage(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    public SimpleBean loadSimpleBean() {
+        return applicationContext.getBean(SimpleBean.class);
+    }
+}

--- a/stable/java/quarkus/tests/data/225-springboot-di-to-quarkus/src/main/java/com/example/apps/SpringDiAnnotationUsage.java
+++ b/stable/java/quarkus/tests/data/225-springboot-di-to-quarkus/src/main/java/com/example/apps/SpringDiAnnotationUsage.java
@@ -1,0 +1,15 @@
+package com.example.apps;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SpringDiAnnotationUsage {
+
+    @Autowired
+    private SimpleBean simpleBean;
+
+    public SimpleBean getSimpleBean() {
+        return simpleBean;
+    }
+}

--- a/stable/java/quarkus/tests/data/241-springboot-cloud-consul-to-quarkus-stork/application.properties
+++ b/stable/java/quarkus/tests/data/241-springboot-cloud-consul-to-quarkus-stork/application.properties
@@ -1,0 +1,3 @@
+spring.cloud.consul.discovery.enabled=true
+spring.cloud.consul.discovery.serviceName=inventory-service
+spring.cloud.consul.discovery.healthCheckPath=/actuator/health

--- a/stable/java/quarkus/tests/data/241-springboot-cloud-consul-to-quarkus-stork/pom.xml
+++ b/stable/java/quarkus/tests/data/241-springboot-cloud-consul-to-quarkus-stork/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.sample</groupId>
+    <artifactId>sample-project</artifactId>
+    <version>0.0.1</version>
+    <name>Sample Project</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-consul-discovery</artifactId>
+            <version>4.1.3</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/stable/java/quarkus/tests/data/242-springboot-devservices-to-quarkus/pom.xml
+++ b/stable/java/quarkus/tests/data/242-springboot-devservices-to-quarkus/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.sample</groupId>
+    <artifactId>sample-project</artifactId>
+    <version>0.0.1</version>
+    <name>Sample Project</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <version>2.7.18</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+            <version>2.9.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <version>2.7.18</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
Addresses comments to improve Quarkus rulesets:


| Effort | Issue | Title (short) | Nature |
|:------:|-------|---------------|--------|
| **1** | [#289](https://github.com/konveyor/rulesets/issues/289) | Fix JMX rule messaging (native vs JMX; Micrometer) | Copy + links in existing rules |
| **3** | [#290](https://github.com/konveyor/rulesets/issues/290) | Improve Spring DI rule (category, table, CDI guidance) | YAML + possible new `when` clauses + tests |
| **3** | [#292](https://github.com/konveyor/rulesets/issues/292) | Explain `@SpringBootApplication` composition in Quarkus terms | Message + optional extra rules |
| **3** | [#294](https://github.com/konveyor/rulesets/issues/294) | Spring Cloud Consul → Quarkus Stork | New rule file + tests + dependency patterns |
| **4** | [#291](https://github.com/konveyor/rulesets/issues/291) | Expand actuator → Quarkus observability mapping | Research + one or many rules/messages |
| **4** | [#298](https://github.com/konveyor/rulesets/issues/298) | Devservices as local alternative for SQL/NoSQL/messaging | Many technology-specific dependency rules or one broad guide |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service discovery migration guidance for Spring Cloud Consul → Quarkus Stork.
  * Recommendation to use Quarkus Dev Services for local/dev infrastructure.

* **Improvements**
  * Broadened Actuator migration guidance to cover health, metrics, info and management endpoints.
  * Expanded detection and mapping guidance for Spring Boot annotations, DI patterns, and JMX migration limitations.

* **Tests**
  * Added and updated test cases, fixtures and sample projects to cover new/revised rules.

* **Documentation**
  * New doc enumerating open ruleset issues and remediation guidance.

* **Chores**
  * CI workflow: updated test invocation to support local execution flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->