### PR TITLE
Update IP address regex pattern in hardcoded IP find rule

### DIFF
--- a/stable/java/00-discovery/0.yaml
+++ b/stable/java/00-discovery/0.yaml
@@ -34,7 +34,7 @@
   - konveyor.io/target=discovery
   when:
     builtin.filecontent:
-      pattern: ([0-9]{1,3}\.){3}[0-9]{1,3}
+      pattern: \b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b
       filePattern: ".*\\.(java|properties)"
   category: mandatory
   effort: 1


### PR DESCRIPTION
The original IP regex pattern was not as specific; it would trigger on valid dates formatted like `yy.mm.dd.MMMMMM`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hardcoded IP address detection rule with stricter pattern matching to reduce false positives and increase accuracy in identifying actual IP address values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->