### PR TITLE
Fix for #379 and #380, JBoss EAP 8.2 channel manifest

### DIFF
--- a/stable/java/eap82/eap_channel_manifest_8_1_upgrade.mta.yaml
+++ b/stable/java/eap82/eap_channel_manifest_8_1_upgrade.mta.yaml
@@ -1,0 +1,12 @@
+- ruleID: eap_channel_manifest_8_1_upgrade-00001
+  description: "The JBoss EAP Channel Manifest 8.1 should be upgraded."
+  category: mandatory
+  effort: 1
+  #links:
+  #  - url: https://docs.redhat.com/en/documentation/red_hat_jboss_enterprise_application_platform/8.2/html/migration_guide/migrate-a-jboss-eap-application-s-maven-project-to-jboss-eap-8-2_default
+  #    title: "Migrate a JBoss EAP Application’s Maven Project to JBoss EAP 8.2"
+  message: The JBoss EAP Channel Manifest `8.1` should be upgraded.
+  when:
+    builtin.filecontent:
+      filePattern: pom\.xml
+      pattern: artifactId>eap-8.1<

--- a/stable/java/eap82/ruleset.yaml
+++ b/stable/java/eap82/ruleset.yaml
@@ -1,0 +1,12 @@
+name: eap82/eap8
+description: This ruleset provides analysis of Maven built applications when migrating from EAP 6/7/8 to 8.2. This ruleset also applies to migrations from EAP XP 6.0 to 7.0, since EAP XP 7.0 has EAP 8.2 underlying.
+labels:
+  - konveyor.io/source=eap6
+  - konveyor.io/source=eap7
+  - konveyor.io/source=eap8
+  - konveyor.io/source=eap81
+  - konveyor.io/target=eap82
+  - konveyor.io/source=eapxp5
+  - konveyor.io/source=eapxp6
+  - konveyor.io/target=eapxp7
+

--- a/stable/java/eap82/tests/data/eap_channel_manifest_8_1_upgrade/pom.xml
+++ b/stable/java/eap82/tests/data/eap_channel_manifest_8_1_upgrade/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>groupId</groupId>
+    <artifactId>artifactId</artifactId>
+    <version>1.0.0</version>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.jboss.eap.plugins</groupId>
+                    <artifactId>eap-maven-plugin</artifactId>
+                    <configuration>
+                        <channels>
+                            <channel>
+                                <manifest>
+                                    <groupId>org.jboss.eap.channels</groupId>
+                                    <artifactId>eap-8.1</artifactId>
+                                </manifest>
+                            </channel>
+                        </channels>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/stable/java/eap82/tests/eap_channel_manifest_8_1_upgrade.test.yaml
+++ b/stable/java/eap82/tests/eap_channel_manifest_8_1_upgrade.test.yaml
@@ -1,0 +1,12 @@
+rulesPath: ../eap_channel_manifest_8_1_upgrade.mta.yaml
+providers:
+  - name: java
+    dataPath: ./data/eap_channel_manifest_8_1_upgrade
+  - name: builtin
+    dataPath: ./data/eap_channel_manifest_8_1_upgrade
+tests:
+  - ruleID: eap_channel_manifest_8_1_upgrade-00001
+    testCases:
+      - name: eap_channel_manifest_8_1_upgrade-1
+        hasIncidents:
+          exactly: 1

--- a/stable/java/eapxp7/eapxp_channel_manifest_6_0_upgrade.mta.yaml
+++ b/stable/java/eapxp7/eapxp_channel_manifest_6_0_upgrade.mta.yaml
@@ -1,0 +1,12 @@
+- ruleID: eapxp_channel_manifest_6_0_upgrade-00001
+  description: "The JBoss EAP XP Channel Manifest 6.0 should be upgraded."
+  category: mandatory
+  effort: 1
+  #links:
+  #  - url: https://docs.redhat.com/en/documentation/red_hat_jboss_enterprise_application_platform/8.2/html/jboss_eap_xp_7.0_upgrade_and_migration_guide/application_migration_default
+  #    title: "JBoss EAP XP 7.0 upgrade and migration guide: Chapter 3. Application Migration"
+  message: The JBoss EAP XP Channel Manifest `6.0` should be upgraded
+  when:
+    builtin.filecontent:
+      filePattern: pom\.xml
+      pattern: artifactId>eap-xp-6.0<

--- a/stable/java/eapxp7/ruleset.yaml
+++ b/stable/java/eapxp7/ruleset.yaml
@@ -1,0 +1,6 @@
+name: eapxp7/eapxp6
+description: This ruleset provides analysis of Maven built applications when migrating from EAP XP 6 to 7.
+labels:
+  - konveyor.io/source=eapxp
+  - konveyor.io/target=eapxp7+
+

--- a/stable/java/eapxp7/tests/data/eapxp_channel_manifest_6_0_upgrade/pom.xml
+++ b/stable/java/eapxp7/tests/data/eapxp_channel_manifest_6_0_upgrade/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>groupId</groupId>
+    <artifactId>artifactId</artifactId>
+    <version>1.0.0</version>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.jboss.eap.plugins</groupId>
+                    <artifactId>eap-maven-plugin</artifactId>
+                    <configuration>
+                        <channels>
+                            <channel>
+                                <manifest>
+                                    <groupId>org.jboss.eap.channels</groupId>
+                                    <artifactId>eap-xp-6.0</artifactId>
+                                </manifest>
+                            </channel>
+                        </channels>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/stable/java/eapxp7/tests/eapxp_channel_manifest_6_0_upgrade.test.yaml
+++ b/stable/java/eapxp7/tests/eapxp_channel_manifest_6_0_upgrade.test.yaml
@@ -1,0 +1,12 @@
+rulesPath: ../eapxp_channel_manifest_6_0_upgrade.mta.yaml
+providers:
+  - name: java
+    dataPath: ./data/eapxp_channel_manifest_6_0_upgrade
+  - name: builtin
+    dataPath: ./data/eapxp_channel_manifest_6_0_upgrade
+tests:
+  - ruleID: eapxp_channel_manifest_6_0_upgrade-00001
+    testCases:
+      - name: eapxp_channel_manifest_6_0_upgrade-1
+        hasIncidents:
+          exactly: 1


### PR DESCRIPTION
- Fixes https://github.com/konveyor/rulesets/issues/379
- Fixes https://github.com/konveyor/rulesets/issues/380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added migration analysis rules for upgrading to JBoss EAP 8.2 and EAP XP 7.
  * New rulesets detect outdated channel manifest configurations in Maven projects requiring upgrades.

* **Tests**
  * Added comprehensive test coverage for new migration rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->