### PR TITLE
Fix for #388, Rules for XP 7.0: Migrate to EAP Maven Plugin for bootable JAR creation

### DIFF
--- a/stable/java/eap82/eap_channel_manifest_8_1_upgrade.mta.yaml
+++ b/stable/java/eap82/eap_channel_manifest_8_1_upgrade.mta.yaml
@@ -2,6 +2,9 @@
   description: "The JBoss EAP Channel Manifest 8.1 should be upgraded."
   category: mandatory
   effort: 1
+  labels:
+    - konveyor.io/source=eap81
+    - konveyor.io/target=eap82
   #links:
   #  - url: https://docs.redhat.com/en/documentation/red_hat_jboss_enterprise_application_platform/8.2/html/migration_guide/migrate-a-jboss-eap-application-s-maven-project-to-jboss-eap-8-2_default
   #    title: "Migrate a JBoss EAP Application’s Maven Project to JBoss EAP 8.2"

--- a/stable/java/eapxp7/eapxp_channel_manifest_6_0_upgrade.mta.yaml
+++ b/stable/java/eapxp7/eapxp_channel_manifest_6_0_upgrade.mta.yaml
@@ -2,6 +2,9 @@
   description: "The JBoss EAP XP Channel Manifest 6.0 should be upgraded."
   category: mandatory
   effort: 1
+  labels:
+    - konveyor.io/source=eapxp
+    - konveyor.io/target=eap7+
   #links:
   #  - url: https://docs.redhat.com/en/documentation/red_hat_jboss_enterprise_application_platform/8.2/html/jboss_eap_xp_7.0_upgrade_and_migration_guide/application_migration_default
   #    title: "JBoss EAP XP 7.0 upgrade and migration guide: Chapter 3. Application Migration"

--- a/stable/java/eapxp7/eapxp_wildfly_jar_maven_plugin_upgrade.mta.yaml
+++ b/stable/java/eapxp7/eapxp_wildfly_jar_maven_plugin_upgrade.mta.yaml
@@ -1,0 +1,12 @@
+- ruleID: eapxp_wildfly_jar_maven_plugin_upgrade-00001
+  description: "The JBOSS EAP WildFly JAR Maven Plugin should be replaced by the JBoss EAP Maven Plugin"
+  category: mandatory
+  effort: 1
+  #links:
+  #  - url: https://docs.redhat.com/en/documentation/red_hat_jboss_enterprise_application_platform/8.2/html/TODO
+  #    title: "TODO"
+  message: The JBOSS EAP WildFly JAR Maven Plugin should be replaced by the JBoss EAP Maven Plugin
+  when:
+    builtin.filecontent:
+      filePattern: pom\.xml
+      pattern: artifactId>wildfly-jar-maven-plugin<

--- a/stable/java/eapxp7/eapxp_wildfly_jar_maven_plugin_upgrade.mta.yaml
+++ b/stable/java/eapxp7/eapxp_wildfly_jar_maven_plugin_upgrade.mta.yaml
@@ -2,6 +2,9 @@
   description: "The JBOSS EAP WildFly JAR Maven Plugin should be replaced by the JBoss EAP Maven Plugin"
   category: mandatory
   effort: 1
+  labels:
+    - konveyor.io/source=eapxp
+    - konveyor.io/target=eap7+
   #links:
   #  - url: https://docs.redhat.com/en/documentation/red_hat_jboss_enterprise_application_platform/8.2/html/TODO
   #    title: "TODO"

--- a/stable/java/eapxp7/tests/data/eapxp_wildfly_jar_maven_plugin_upgrade/pom.xml
+++ b/stable/java/eapxp7/tests/data/eapxp_wildfly_jar_maven_plugin_upgrade/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>groupId</groupId>
+    <artifactId>artifactId</artifactId>
+    <version>1.0.0</version>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-jar-maven-plugin</artifactId>
+                    <configuration>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/stable/java/eapxp7/tests/eapxp_wildfly_jar_maven_plugin_upgrade.test.yaml
+++ b/stable/java/eapxp7/tests/eapxp_wildfly_jar_maven_plugin_upgrade.test.yaml
@@ -1,0 +1,12 @@
+rulesPath: ../eapxp_wildfly_jar_maven_plugin_upgrade.mta.yaml
+providers:
+  - name: java
+    dataPath: ./data/eapxp_wildfly_jar_maven_plugin_upgrade
+  - name: builtin
+    dataPath: ./data/eapxp_wildfly_jar_maven_plugin_upgrade
+tests:
+  - ruleID: eapxp_wildfly_jar_maven_plugin_upgrade-00001
+    testCases:
+      - name: eapxp_wildfly_jar_maven_plugin_upgrade-1
+        hasIncidents:
+          exactly: 1


### PR DESCRIPTION
Fix issue #388
Note that the link to documentation can't be set currently, will require an extra fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detection for Maven `wildfly-jar-maven-plugin` entries to flag them for migration, with corresponding upgrade guidance.

* **Tests**
  * Added a new test bundle and sample Maven `pom.xml` to validate the rule and ensure the expected incident count.

* **Documentation**
  * Updated channel manifest upgrade rules to include source/target labels for clearer reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->